### PR TITLE
Improvements based upon feedback (see description)

### DIFF
--- a/network/dns_packet.ksy
+++ b/network/dns_packet.ksy
@@ -129,13 +129,6 @@ types:
         value: (flag & 0b0000_0000_0000_1111) >> 0
         
 enums:
-  qr:
-    0x0: query
-    0x1: response
-  flags_type:
-    0x0100: "Query_Standard_Query_Not_Auth_No_Trunc_Recursive_Non_Auth_Unacceptable"
-    0x8180: "Response_Standard_Query_Not_Auth_No_Trunc_Recursive_Can_Recurse_No_Auth_Non_Auth_Unacceptable_No_Error"
-    0x8183: "Response_Standard_Query_Not_Auth_No_Trunc_Recursive_Can_Recurse_No_Auth_Non_Auth_Unacceptable_No_Such_Name"
   class_type:
     1: in
     2: cs


### PR DESCRIPTION
- Comment used rather than application
- Flags instance used rather than enum
- Updated docs and ids to align with RFC rather than guesswork
- Added unit to ttl
- Added support for A-class records now I've found more samples
- Updated expressions to use newly discovered "or" function and instanced fields for clarity
- Removed dead code
- Dequoted enum-values based upon feedback (needed to leave null given it causes problems otherwise as a literal)