### PR TITLE
Add binary image lay for andes firmware found in mediatek 76x0U devices

### DIFF
--- a/firmware/andes_firmware.ksy
+++ b/firmware/andes_firmware.ksy
@@ -1,10 +1,14 @@
 meta:
   id: andes_firmware
   endian: le
+  title: Andes Firmware Image layout as seen in MT76 Wifi Chipsets
+  license: CC0-1.0
+  application: Firmware Image wifi chipset
+  doc: Firmware image found with MediaTek MT76xx wifi chipsets. 
 seq:
   - id: image_header
     type: image_header
-	size: 32
+    size: 32
   - id: ilm
     size: image_header.ilm_len
   - id: dlm

--- a/firmware/andes_firmware.ksy
+++ b/firmware/andes_firmware.ksy
@@ -1,0 +1,28 @@
+meta:
+  id: andes_firmware
+  endian: le
+seq:
+  - id: image_header
+    type: image_header
+	size: 32
+  - id: ilm
+    size: image_header.ilm_len
+  - id: dlm
+    size: image_header.dlm_len
+types:
+  image_header:
+    seq:
+      - id: ilm_len
+        type: u4
+      - id: dlm_len
+        type: u4
+      - id: fw_ver
+        type: u2
+      - id: build_ver
+        type: u2
+      - id: extra
+        type: u4
+      - id: build_time
+        type: str
+        size: 16
+        encoding: UTF-8


### PR DESCRIPTION
Add a `firmware` directory and a firmware image format for an obscure platform.

I can see there being many `firmware` image formats and I think these are distinct from `executable` formats which already have a directory. 

The format specified here is enough to parse out a firmware image for use with driver development, but it misses the bit fields that encode the firmware version. The correct way to do this is [documented in a blog post here][1], it is just a simple bit mask:

    print("fw version: {}.{}.{}"
        .format(
            (fw_ver & 0xf000) >> 8,
            (fw_ver & 0x0f00) >> 8,
            fw_ver & 0x00ff))

I am not sure how to implement this and I am not entirely sure it is required.

There are also firmware images with the documented header used as a format trailer. The code I have currently tries to parse the header, checks the lengths and if that fails tries to parse the trailer. I don't think there is a way to model this in kaitai, or that it is desirable. 

[1]: http://adventurist.me/posts/0225/