### PR TITLE
added additional constant structures

### DIFF
--- a/executable/java_class.ksy
+++ b/executable/java_class.ksy
@@ -1,3 +1,4 @@
+# https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.1
 meta:
   id: java_class
   endian: be
@@ -39,6 +40,12 @@ seq:
     type: method_info
     repeat: expr
     repeat-expr: methods_count
+  - id: attributes_count
+    type: u2
+  - id: attributes
+    type: attribute_info
+    repeat: expr
+    repeat-expr: attributes_count
 types:
   # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4
   constant_pool_entry:
@@ -46,15 +53,9 @@ types:
       - id: tag
         type: u1
         enum: tag_enum
-      - id: utf8_cp_info
-        type: utf8_cp_info
-        if: tag == tag_enum::utf8
       - id: class_cp_info
         type: class_cp_info
         if: tag == tag_enum::class_type
-      - id: name_and_type_cp_info
-        type: name_and_type_cp_info
-        if: tag == tag_enum::name_and_type
       - id: field_ref_cp_info
         type: field_ref_cp_info
         if: tag == tag_enum::field_ref
@@ -64,6 +65,27 @@ types:
       - id: interface_method_ref_cp_info
         type: interface_method_ref_cp_info
         if: tag == tag_enum::interface_method_ref
+      - id: string_cp_info
+        type: string_cp_info
+        if: tag == tag_enum::string
+      - id: integer_cp_info
+        type: integer_cp_info
+        if: tag == tag_enum::integer
+      - id: float_cp_info
+        type: float_cp_info
+        if: tag == tag_enum::float
+      - id: long_cp_info
+        type: long_cp_info
+        if: tag == tag_enum::long
+      - id: double_cp_info
+        type: double_cp_info
+        if: tag == tag_enum::double
+      - id: name_and_type_cp_info
+        type: name_and_type_cp_info
+        if: tag == tag_enum::name_and_type
+      - id: utf8_cp_info
+        type: utf8_cp_info
+        if: tag == tag_enum::utf8
     enums:
       tag_enum:
         7: class_type
@@ -80,6 +102,66 @@ types:
         15: method_handle
         16: method_type
         18: invoke_dynamic
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.1
+  class_cp_info:
+    seq:
+      - id: name_index
+        type: u2
+    instances:
+      name:
+        value: _root.constant_pool[name_index - 1]
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.2
+  field_ref_cp_info:
+    seq:
+      - id: class_index
+        type: u2
+      - id: name_and_type_index
+        type: u2
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.2
+  method_ref_cp_info:
+    seq:
+      - id: class_index
+        type: u2
+      - id: name_and_type_index
+        type: u2
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.2
+  interface_method_ref_cp_info:
+    seq:
+      - id: class_index
+        type: u2
+      - id: name_and_type_index
+        type: u2
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.3
+  string_cp_info:
+    seq:
+      - id: string_index
+        type: u2
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.4
+  integer_cp_info:
+    seq:
+      - id: value
+        type: u4
+  float_cp_info:
+    seq:
+      - id: value
+        type: f4
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.5
+  long_cp_info:
+    seq:
+      - id: value
+        type: u8
+  double_cp_info:
+    seq:
+      - id: value
+        type: f8
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.6
+  name_and_type_cp_info:
+    seq:
+      - id: name_index
+        type: u2
+      - id: descriptor_index
+        type: u2
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.7
   utf8_cp_info:
     seq:
       - id: str_len
@@ -88,35 +170,34 @@ types:
         type: str
         size: str_len
         encoding: UTF-8
-  class_cp_info:
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.8
+  method_handle_cp_info:
     seq:
-      - id: name_index
+      - id: reference_kind
+        type: u1
+        enum: reference_kind_enum
+      - id: reference_index
         type: u2
-    instances:
-      name:
-        value: _root.constant_pool[name_index - 1]
-  name_and_type_cp_info:
+    enums:
+      reference_kind_enum:
+        1: get_field
+        2: get_static
+        3: put_field
+        4: put_static
+        5: invoke_virtual
+        6: invoke_static
+        7: invoke_special
+        8: new_invoke_special
+        9: invoke_interface
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.9
+  method_type_cp_info:
     seq:
-      - id: name_index
-        type: u2
       - id: descriptor_index
         type: u2
-  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.2
-  field_ref_cp_info:
+  # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.10
+  invoke_dynamic_cp_info:
     seq:
-      - id: class_index
-        type: u2
-      - id: name_and_type_index
-        type: u2
-  method_ref_cp_info:
-    seq:
-      - id: class_index
-        type: u2
-      - id: name_and_type_index
-        type: u2
-  interface_method_ref_cp_info:
-    seq:
-      - id: class_index
+      - id: bootstrap_method_attr_index
         type: u2
       - id: name_and_type_index
         type: u2
@@ -132,11 +213,11 @@ types:
       - id: attributes_count
         type: u2
       - id: attributes
-        type: attribute
+        type: attribute_info
         repeat: expr
         repeat-expr: attributes_count
   # https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7
-  attribute:
+  attribute_info:
     seq:
       - id: attribute_name_index
         type: u2
@@ -156,6 +237,6 @@ types:
       - id: attributes_count
         type: u2
       - id: attributes
-        type: attribute
+        type: attribute_info
         repeat: expr
         repeat-expr: attributes_count


### PR DESCRIPTION
This adds all the constant structures for `.class` files from https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html

I also reordered everything so it is in the same order as the description page. I also found a bug that probably cannot be fixed without an overhaul of kaitai struct itself but I will open a separate issue for that. For now this is definitely an improvement over the previous version that wouldn't even accept the most basic class files.