### PR TITLE
Stop reading PNGs after the IEND chunk

### DIFF
--- a/image/png.ksy
+++ b/image/png.ksy
@@ -19,7 +19,8 @@ seq:
   # The rest of the chunks
   - id: chunks
     type: chunk
-    repeat: eos
+    repeat: until
+    repeat-until: _.type == "IEND" or _io.eof
 types:
   chunk:
     seq:


### PR DESCRIPTION
If there are extra bytes at the end of the PNG (e.g. if the PNG is embedded in some other sort of file), the parser will try to read in new chunks even if they're nonsensical, and will often fail because of
invalid data in the garbage chunk (like a "chunk size" larger than the file) By stopping at the IEND chunk, the parser won't keep trying to read more chunks past the end of the file.