### PR TITLE
Add Fallout1 and Fallout2 .dat file formats

### DIFF
--- a/game/fallout2_dat.ksy
+++ b/game/fallout2_dat.ksy
@@ -1,0 +1,63 @@
+meta:
+  id: fallout2_dat
+  endian: le
+  application: Fallout2
+types:
+  pstr:
+    seq:
+      - id: size
+        type: u4
+      - id: str
+        type: str
+        size: size
+        encoding: ASCII
+  footer:
+    seq:
+      - id: index_size
+        type: u4
+      - id: file_size
+        type: u4
+  index:
+    seq:
+      - id: file_count
+        type: u4
+      - id: files
+        type: file
+        repeat: expr
+        repeat-expr: file_count
+  file:
+    seq:
+      - id: name
+        type: pstr
+      - id: flags
+        type: u1
+        enum: compression
+      - id: size_unpacked
+        type: u4
+      - id: size_packed
+        type: u4
+      - id: offset
+        type: u4
+    instances:
+      contents:
+        io: _root._io
+        pos: offset
+        size: size_unpacked
+        if: flags == compression::none
+      contents:
+        io: _root._io
+        pos: offset
+        size: size_packed
+        process: zlib
+        if: flags == compression::zlib
+instances:
+  footer:
+    pos: _io.size - 8
+    type: footer
+  index:
+    pos: _io.size - 8 - footer.index_size
+    type: index
+enums:
+  compression:
+    0: none
+    1: zlib

--- a/game/fallout2_dat.ksy
+++ b/game/fallout2_dat.ksy
@@ -2,6 +2,7 @@ meta:
   id: fallout2_dat
   endian: le
   application: Fallout2
+  license: CC0-1.0
 types:
   pstr:
     seq:

--- a/game/fallout_dat.ksy
+++ b/game/fallout_dat.ksy
@@ -2,6 +2,7 @@ meta:
   id: fallout_dat
   endian: be
   application: Fallout
+  license: CC0-1.0
 seq:
   - id: folder_count
     type: u4

--- a/game/fallout_dat.ksy
+++ b/game/fallout_dat.ksy
@@ -1,0 +1,66 @@
+meta:
+  id: fallout_dat
+  endian: be
+  application: Fallout
+seq:
+  - id: folder_count
+    type: u4
+  - id: unknown
+    type: u4
+  - id: unknown
+    type: u4
+  - id: timestamp
+    type: u4
+  - id: folder_names
+    type: pstr
+    repeat: expr
+    repeat-expr: folder_count
+  - id: folders
+    type: folder
+    repeat: expr
+    repeat-expr: folder_count
+types:
+  pstr:
+    seq:
+      - id: size
+        type: u1
+      - id: str
+        type: str
+        size: size
+        encoding: ASCII
+  folder:
+    seq:
+      - id: file_count
+        type: u4
+      - id: unknown
+        type: u4
+      - id: flags
+        type: u4
+      - id: timestamp
+        type: u4
+      - id: files
+        type: file
+        repeat: expr
+        repeat-expr: file_count
+  file:
+    seq:
+      - id: name
+        type: pstr
+      - id: flags
+        type: u4
+        enum: compression
+      - id: offset
+        type: u4
+      - id: size_unpacked
+        type: u4
+      - id: size_packed
+        type: u4
+    instances:
+      contents:
+        io: _root._io
+        pos: offset
+        size: "(flags == compression::none) ? size_unpacked : size_packed"
+enums:
+  compression:
+    32: none
+    64: lzss


### PR DESCRIPTION
As in the title, these format descriptions are for the .dat archives in Fallout1 and Fallout2 games.

Note that Fallout1 archive use a custom LZSS compression algorithm that requires additional code for decompression.