### PR TITLE
Removed redundant type

### DIFF
--- a/network/tls_client_hello.ksy
+++ b/network/tls_client_hello.ksy
@@ -54,14 +54,9 @@ types:
         type: u2
 
       - id: cipher_suites
-        type: cipher_suite
+        type: u2
         repeat: expr
         repeat-expr: len/2
-
-  cipher_suite:
-    seq:
-      - id: cipher_suite
-        type: u2
 
   compression_methods:
     seq:


### PR DESCRIPTION
Removes a redundant type in tls client hello parser
Earlier -
```
for cs in cipher_suites.cipher_suites:
    print(cs.cipher_suite)
```
![screenshot from 2017-06-22 06-15-37](https://user-images.githubusercontent.com/16747982/27412471-842e303e-5712-11e7-81df-82febcfb7f60.png)
Now -
```
for cs in cipher_suites.cipher_suites:
    print(cs)
```
![screenshot from 2017-06-22 06-16-38](https://user-images.githubusercontent.com/16747982/27412481-8e55e278-5712-11e7-8e4e-5c6834a34a91.png)
