### PR TITLE
Extend and improve support for the Mach-O file format

### DIFF
--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -196,6 +196,7 @@ types:
             'load_command_type::dylib_code_sign_drs' : linkedit_data_command
             'load_command_type::code_signature'      : code_signature_command
             'load_command_type::encryption_info_64'  : encryption_info_command_64
+            'load_command_type::twolevel_hints'      : twolevel_hints_command
     -webide-representation: '{type}: {body}'
   vm_prot:
     seq:
@@ -751,6 +752,12 @@ types:
       - id: cryptid
         type: u4
       - id: pad
+        type: u4
+  twolevel_hints_command:
+    seq:
+      - id: offset
+        type: u4
+      - id: nhints
         type: u4
   version_min_command:
     seq:

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -175,6 +175,8 @@ types:
             'load_command_type::symtab'              : symtab_command
             'load_command_type::dysymtab'            : dysymtab_command
             'load_command_type::load_dylinker'       : dylinker_command
+            'load_command_type::id_dylinker'         : dylinker_command
+            'load_command_type::dyld_environment'    : dylinker_command
             'load_command_type::uuid'                : uuid_command
             'load_command_type::version_min_macosx'  : version_min_command
             'load_command_type::version_min_iphoneos': version_min_command

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -171,6 +171,7 @@ types:
           switch-on: type
           cases:
             'load_command_type::segment_64'              : segment_command_64
+            'load_command_type::dyld_info'               : dyld_info_command
             'load_command_type::dyld_info_only'          : dyld_info_command
             'load_command_type::symtab'                  : symtab_command
             'load_command_type::dysymtab'                : dysymtab_command
@@ -199,6 +200,10 @@ types:
             'load_command_type::encryption_info_64'      : encryption_info_command_64
             'load_command_type::twolevel_hints'          : twolevel_hints_command
             'load_command_type::linker_option'           : linker_option_command
+            'load_command_type::sub_framework'           : sub_command
+            'load_command_type::sub_umbrella'            : sub_command
+            'load_command_type::sub_client'              : sub_command
+            'load_command_type::sub_library'             : sub_command
     -webide-representation: '{type}: {body}'
   vm_prot:
     seq:
@@ -770,6 +775,10 @@ types:
         encoding: utf-8
         repeat: expr
         repeat-expr: count
+  sub_command:
+    seq:
+        - id: name
+          type: lc_str
   version_min_command:
     seq:
       - id: version

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -102,8 +102,7 @@ enums:
     0x25      : version_min_iphoneos
     0x26      : function_starts
     0x27      : dyld_environment
-    0x28      : main
-    0x80000028: main2
+    0x80000028: main
     0x29      : data_in_code
     0x2A      : source_version
     0x2B      : dylib_code_sign_drs

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -184,6 +184,11 @@ types:
             'load_command_type::source_version'      : source_version_command
             'load_command_type::main'                : entry_point_command
             'load_command_type::load_dylib'          : dylib_command
+            'load_command_type::load_upward_dylib'   : dylib_command
+            'load_command_type::id_dylib'            : dylib_command
+            'load_command_type::load_weak_dylib'     : dylib_command
+            'load_command_type::lazy_load_dylib'     : dylib_command
+            'load_command_type::reexport_dylib'      : dylib_command
             'load_command_type::rpath'               : rpath_command
             'load_command_type::function_starts'     : linkedit_data_command
             'load_command_type::data_in_code'        : linkedit_data_command

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -170,33 +170,35 @@ types:
         type:
           switch-on: type
           cases:
-            'load_command_type::segment_64'          : segment_command_64
-            'load_command_type::dyld_info_only'      : dyld_info_command
-            'load_command_type::symtab'              : symtab_command
-            'load_command_type::dysymtab'            : dysymtab_command
-            'load_command_type::load_dylinker'       : dylinker_command
-            'load_command_type::id_dylinker'         : dylinker_command
-            'load_command_type::dyld_environment'    : dylinker_command
-            'load_command_type::uuid'                : uuid_command
-            'load_command_type::version_min_macosx'  : version_min_command
-            'load_command_type::version_min_iphoneos': version_min_command
-            'load_command_type::version_min_tvos'    : version_min_command
-            'load_command_type::version_min_watchos' : version_min_command
-            'load_command_type::source_version'      : source_version_command
-            'load_command_type::main'                : entry_point_command
-            'load_command_type::load_dylib'          : dylib_command
-            'load_command_type::load_upward_dylib'   : dylib_command
-            'load_command_type::id_dylib'            : dylib_command
-            'load_command_type::load_weak_dylib'     : dylib_command
-            'load_command_type::lazy_load_dylib'     : dylib_command
-            'load_command_type::reexport_dylib'      : dylib_command
-            'load_command_type::rpath'               : rpath_command
-            'load_command_type::function_starts'     : linkedit_data_command
-            'load_command_type::data_in_code'        : linkedit_data_command
-            'load_command_type::dylib_code_sign_drs' : linkedit_data_command
-            'load_command_type::code_signature'      : code_signature_command
-            'load_command_type::encryption_info_64'  : encryption_info_command_64
-            'load_command_type::twolevel_hints'      : twolevel_hints_command
+            'load_command_type::segment_64'              : segment_command_64
+            'load_command_type::dyld_info_only'          : dyld_info_command
+            'load_command_type::symtab'                  : symtab_command
+            'load_command_type::dysymtab'                : dysymtab_command
+            'load_command_type::load_dylinker'           : dylinker_command
+            'load_command_type::id_dylinker'             : dylinker_command
+            'load_command_type::dyld_environment'        : dylinker_command
+            'load_command_type::uuid'                    : uuid_command
+            'load_command_type::version_min_macosx'      : version_min_command
+            'load_command_type::version_min_iphoneos'    : version_min_command
+            'load_command_type::version_min_tvos'        : version_min_command
+            'load_command_type::version_min_watchos'     : version_min_command
+            'load_command_type::source_version'          : source_version_command
+            'load_command_type::main'                    : entry_point_command
+            'load_command_type::load_dylib'              : dylib_command
+            'load_command_type::load_upward_dylib'       : dylib_command
+            'load_command_type::id_dylib'                : dylib_command
+            'load_command_type::load_weak_dylib'         : dylib_command
+            'load_command_type::lazy_load_dylib'         : dylib_command
+            'load_command_type::reexport_dylib'          : dylib_command
+            'load_command_type::rpath'                   : rpath_command
+            'load_command_type::function_starts'         : linkedit_data_command
+            'load_command_type::data_in_code'            : linkedit_data_command
+            'load_command_type::dylib_code_sign_drs'     : linkedit_data_command
+            'load_command_type::linker_optimization_hint': linkedit_data_command
+            'load_command_type::code_signature'          : code_signature_command
+            'load_command_type::encryption_info_64'      : encryption_info_command_64
+            'load_command_type::twolevel_hints'          : twolevel_hints_command
+            'load_command_type::linker_option'           : linker_option_command
     -webide-representation: '{type}: {body}'
   vm_prot:
     seq:
@@ -759,6 +761,15 @@ types:
         type: u4
       - id: nhints
         type: u4
+  linker_option_command:
+    seq:
+      - id: count
+        type: u4
+      - id: strings
+        type: strz
+        encoding: utf-8
+        repeat: expr
+        repeat-expr: count
   version_min_command:
     seq:
       - id: version

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -204,6 +204,7 @@ types:
             'load_command_type::sub_umbrella'            : sub_command
             'load_command_type::sub_client'              : sub_command
             'load_command_type::sub_library'             : sub_command
+            'load_command_type::routines_64'             : routines_command_64
     -webide-representation: '{type}: {body}'
   vm_prot:
     seq:
@@ -779,6 +780,24 @@ types:
     seq:
         - id: name
           type: lc_str
+  routines_command_64:
+    seq:
+        - id: init_address
+          type: u8
+        - id: init_module
+          type: u8
+        - id: reserved1
+          type: u8
+        - id: reserved2
+          type: u8
+        - id: reserved3
+          type: u8
+        - id: reserved4
+          type: u8
+        - id: reserved5
+          type: u8
+        - id: reserved6
+          type: u8
   version_min_command:
     seq:
       - id: version

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -171,20 +171,23 @@ types:
         type:
           switch-on: type
           cases:
-            'load_command_type::segment_64'        : segment_command_64
-            'load_command_type::dyld_info_only'    : dyld_info_command
-            'load_command_type::symtab'            : symtab_command
-            'load_command_type::dysymtab'          : dysymtab_command
-            'load_command_type::load_dylinker'     : dylinker_command
-            'load_command_type::uuid'              : uuid_command
-            'load_command_type::version_min_macosx': version_min_command
-            'load_command_type::source_version'    : source_version_command
-            'load_command_type::main'              : entry_point_command
-            'load_command_type::load_dylib'        : dylib_command
-            'load_command_type::rpath'             : rpath_command
-            'load_command_type::function_starts'   : linkedit_data_command
-            'load_command_type::data_in_code'      : linkedit_data_command
-            'load_command_type::code_signature'    : code_signature_command
+            'load_command_type::segment_64'          : segment_command_64
+            'load_command_type::dyld_info_only'      : dyld_info_command
+            'load_command_type::symtab'              : symtab_command
+            'load_command_type::dysymtab'            : dysymtab_command
+            'load_command_type::load_dylinker'       : dylinker_command
+            'load_command_type::uuid'                : uuid_command
+            'load_command_type::version_min_macosx'  : version_min_command
+            'load_command_type::version_min_iphoneos': version_min_command
+            'load_command_type::version_min_tvos'    : version_min_command
+            'load_command_type::version_min_watchos' : version_min_command
+            'load_command_type::source_version'      : source_version_command
+            'load_command_type::main'                : entry_point_command
+            'load_command_type::load_dylib'          : dylib_command
+            'load_command_type::rpath'               : rpath_command
+            'load_command_type::function_starts'     : linkedit_data_command
+            'load_command_type::data_in_code'        : linkedit_data_command
+            'load_command_type::code_signature'      : code_signature_command
     -webide-representation: '{type}: {body}'
   vm_prot:
     seq:

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -97,7 +97,7 @@ enums:
     0x21      : encryption_info    # encrypted segment information
     0x22      : dyld_info          # compressed dyld information
     0x80000022: dyld_info_only     # compressed dyld information only
-    0x23      : load_upward_dylib
+    0x80000023: load_upward_dylib
     0x24      : version_min_macosx
     0x25      : version_min_iphoneos
     0x26      : function_starts

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -191,6 +191,7 @@ types:
             'load_command_type::rpath'               : rpath_command
             'load_command_type::function_starts'     : linkedit_data_command
             'load_command_type::data_in_code'        : linkedit_data_command
+            'load_command_type::dylib_code_sign_drs' : linkedit_data_command
             'load_command_type::code_signature'      : code_signature_command
             'load_command_type::encryption_info_64'  : encryption_info_command_64
     -webide-representation: '{type}: {body}'

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -193,6 +193,7 @@ types:
             'load_command_type::function_starts'     : linkedit_data_command
             'load_command_type::data_in_code'        : linkedit_data_command
             'load_command_type::code_signature'      : code_signature_command
+            'load_command_type::encryption_info_64'  : encryption_info_command_64
     -webide-representation: '{type}: {body}'
   vm_prot:
     seq:
@@ -739,6 +740,16 @@ types:
       - id: release
         type: u1
     -webide-representation: '{major:dec}.{minor:dec}'
+  encryption_info_command_64:
+    seq:
+      - id: cryptoff
+        type: u4
+      - id: cryptsize
+        type: u4
+      - id: cryptid
+        type: u4
+      - id: pad
+        type: u4
   version_min_command:
     seq:
       - id: version

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -44,6 +44,7 @@ enums:
     0x1000000:  abi64     # flag
     0x1000007:  x86_64    # abi64 | i386
     0x1000012:  powerpc64 # abi64 | powerpc
+    0x100000c:  arm64     # abi64 | arm
   file_type:
     # http://opensource.apple.com//source/xnu/xnu-1456.1.26/EXTERNAL_HEADERS/mach-o/loader.h
     0x1: object      # relocatable object file

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -196,8 +196,10 @@ types:
             'load_command_type::data_in_code'            : linkedit_data_command
             'load_command_type::dylib_code_sign_drs'     : linkedit_data_command
             'load_command_type::linker_optimization_hint': linkedit_data_command
+            'load_command_type::segment_split_info'      : linkedit_data_command
             'load_command_type::code_signature'          : code_signature_command
-            'load_command_type::encryption_info_64'      : encryption_info_command_64
+            'load_command_type::encryption_info_64'      : encryption_info_command
+            'load_command_type::encryption_info'         : encryption_info_command
             'load_command_type::twolevel_hints'          : twolevel_hints_command
             'load_command_type::linker_option'           : linker_option_command
             'load_command_type::sub_framework'           : sub_command
@@ -205,6 +207,7 @@ types:
             'load_command_type::sub_client'              : sub_command
             'load_command_type::sub_library'             : sub_command
             'load_command_type::routines_64'             : routines_command_64
+            'load_command_type::routines'                : routines_command
     -webide-representation: '{type}: {body}'
   vm_prot:
     seq:
@@ -751,7 +754,7 @@ types:
       - id: release
         type: u1
     -webide-representation: '{major:dec}.{minor:dec}'
-  encryption_info_command_64:
+  encryption_info_command:
     seq:
       - id: cryptoff
         type: u4
@@ -761,6 +764,7 @@ types:
         type: u4
       - id: pad
         type: u4
+        if: _root.magic == magic_type::macho_be_x64 or _root.magic == magic_type::macho_le_x64
   twolevel_hints_command:
     seq:
       - id: offset
@@ -798,6 +802,24 @@ types:
           type: u8
         - id: reserved6
           type: u8
+  routines_command:
+    seq:
+        - id: init_address
+          type: u4
+        - id: init_module
+          type: u4
+        - id: reserved1
+          type: u4
+        - id: reserved2
+          type: u4
+        - id: reserved3
+          type: u4
+        - id: reserved4
+          type: u4
+        - id: reserved5
+          type: u4
+        - id: reserved6
+          type: u4
   version_min_command:
     seq:
       - id: version


### PR DESCRIPTION
This pull request aims at providing the following changes:

- Add support for arm64 cpu type
- Fix handling of `LC_MAIN` load command
- Fix `load_upward_dylib` load command type
- Add support and handle most of the missing commands, adding the declarations of the struct they represent where necessary:
	
	- `LC_ROUTINES`
	- `LC_ENCRYPTION_INFO` and `LC_ENCRYPTION_INFO_64`
	- `LC_SEGMENT_SPLIT_INFO`
	- `LC_ROUTINES_64`
	- `LC_SUB_FRAMEWORK`, `LC_SUB_CLIENT`, `LC_SUB_UMBRELLA` and `LC_SUB_LIBRARY`
	- `LC_LINKER_OPTION`
	- `LC_TWOLEVEL_HINTS`
	- `LC_ID_DYLINKER`
	- `LC_DYLD_ENVIRONMENT`
	- `LC_DYLIB_CODE_SIGN_DRS`
	- `LC_VERSION_MIN_{IPHONEOS,TVOS,WATCHOS}`

Please, let me know if the declaration needs to be improved with regards to style conventions or other factors. I would be happy to make any change, if required. 