### PR TITLE
Updated iNES format

### DIFF
--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -1,10 +1,10 @@
 # TODO: Support NES 2.0
-doc-ref: https://wiki.nesdev.com/w/index.php/INES
 meta:
   id: ines
   file-extension: nes
   encoding: ASCII
   license: WTFPL
+doc-ref: https://wiki.nesdev.com/w/index.php/INES
 seq:
   - id: header
     type: header

--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -1,3 +1,4 @@
+# TODO: Support NES 2.0
 doc-ref: https://wiki.nesdev.com/w/index.php/INES
 meta:
   id: ines
@@ -32,8 +33,7 @@ types:
       - id: f10
         type: f10
         doc: this one is unofficial
-      - id: zero_fill
-        size: 4
+      - contents: [0, 0, 0, 0, 0]
     instances:
       # TODO: Add an enum for mapper. https://wiki.nesdev.com/w/index.php/List_of_mappers
       mapper:
@@ -73,23 +73,23 @@ types:
             doc: Determines if it is made for a Nintendo VS Unisystem or not
       f9:
         seq:
-          - id: reserved
-            type: b7
+          # TODO: enforce zero (similarly to "contents", but on bit level)
+          - type: b7
           - id: tv_system
             type: b1
             doc: if 0, NTSC. If 1, PAL.
       f10:
         seq:
-          - id: nothing1
-            type: b2
+          # TODO: enforce zero (similarly to "contents", but on bit level)
+          - type: b2
           - id: bus_conflict
             type: b1
             doc: If 0, no bus conflicts. If 1, bus conflicts.
           - id: prg_ram
             type: b1
             doc: If 0, PRG ram is present. If 1, not present.
-          - id: nothing2
-            type: b2
+          # TODO: enforce zero (similarly to "contents", but on bit level)
+          - type: b2
           - id: tv_system
             type: b2
             doc: if 0, NTSC. If 2, PAL. If 1 or 3, dual compatible.

--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -7,8 +7,8 @@ meta:
 doc-ref: https://wiki.nesdev.com/w/index.php/INES
 seq:
   - id: header
-    type: header
     size: 16
+    type: header
   - id: trainer
     size: 512
     if: header.f6.trainer
@@ -20,8 +20,8 @@ seq:
     type: playchoice10
     if: header.f7.playchoice10
   - id: title
-    type: str
     size-eos: true # Usually only 128/127 bytes
+    type: str
     if: not _io.eof
 types:
   header:
@@ -35,22 +35,23 @@ types:
         type: u1
         doc: Size of CHR ROM in 8 KB units (Value 0 means the board uses CHR RAM)
       - id: f6
+        size: 1
         type: f6
-        size: 1
       - id: f7
-        type: f7
         size: 1
+        type: f7
       - id: len_prg_ram
         type: u1
         doc: Size of PRG RAM in 8 KB units (Value 0 infers 8 KB for compatibility; see PRG RAM circuit on nesdev.com)
       - id: f9
+        size: 1
         type: f9
-        size: 1
       - id: f10
-        type: f10
         size: 1
+        type: f10
         doc: this one is unofficial
-      - contents: [0, 0, 0, 0, 0]
+      - id: reserved
+        contents: [0, 0, 0, 0, 0]
     instances:
       # TODO: Add an enum for mapper. https://wiki.nesdev.com/w/index.php/List_of_mappers
       mapper:
@@ -99,7 +100,8 @@ types:
         doc-ref: https://wiki.nesdev.com/w/index.php/INES#Flags_9
         seq:
           # TODO: enforce zero (similarly to "contents", but on bit level)
-          - type: b7
+          - id: reserved
+            type: b7
           - id: tv_system
             type: b1
             enum: tv_system
@@ -112,7 +114,8 @@ types:
         doc-ref: https://wiki.nesdev.com/w/index.php/INES#Flags_10
         seq:
           # TODO: enforce zero (similarly to "contents", but on bit level)
-          - type: b2
+          - id: reserved1
+            type: b2
           - id: bus_conflict
             type: b1
             doc: If 0, no bus conflicts. If 1, bus conflicts.
@@ -121,7 +124,8 @@ types:
             type: b1
             doc: If 0, PRG ram is present. If 1, not present.
           # TODO: enforce zero (similarly to "contents", but on bit level)
-          - type: b2
+          - id: reserved2
+            type: b2
           - id: tv_system
             type: b2
             enum: tv_system

--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -9,8 +9,16 @@ seq:
   - id: header
     type: header
     size: 16
-  - id: rom
-    size-eos: true
+  - id: trainer
+    size: 512
+    if: header.f6.trainer
+  - id: prg_rom
+    size: header.prg_rom_size * 16384
+  - id: chr_rom
+    size: header.chr_rom_size * 8192
+  - id: playchoice
+    type: playchoice
+    if: header.f7.playchoice
 types:
   header:
     seq:
@@ -46,10 +54,11 @@ types:
         doc-ref: https://wiki.nesdev.com/w/index.php/Mapper
     types:
       f6:
+        doc-ref: https://wiki.nesdev.com/w/index.php/INES#Flags_6
         seq:
           - id: lower_mapper
             type: b4
-            doc: Lower nibble of mapper number (see https://wiki.nesdev.com/w/index.php/Mapper)
+            doc: Lower nibble of mapper number
           - id: four_screen
             type: b1
             doc: Ignore mirroring control or above mirroring bit; instead provide four-screen VRAM
@@ -68,10 +77,11 @@ types:
             0: horizontal
             1: vertical
       f7:
+        doc-ref: https://wiki.nesdev.com/w/index.php/INES#Flags_7
         seq:
           - id: upper_mapper
             type: b4
-            doc: Upper nibble of mapper number (see https://wiki.nesdev.com/w/index.php/Mapper)
+            doc: Upper nibble of mapper number
           - id: format
             type: b2
             doc: If equal to 2, flags 8-15 are in NES 2.0 format
@@ -82,6 +92,7 @@ types:
             type: b1
             doc: Determines if it is made for a Nintendo VS Unisystem or not
       f9:
+        doc-ref: https://wiki.nesdev.com/w/index.php/INES#Flags_9
         seq:
           # TODO: enforce zero (similarly to "contents", but on bit level)
           - type: b7
@@ -94,6 +105,7 @@ types:
             0: ntsc
             1: pal
       f10:
+        doc-ref: https://wiki.nesdev.com/w/index.php/INES#Flags_10
         seq:
           # TODO: enforce zero (similarly to "contents", but on bit level)
           - type: b2
@@ -116,3 +128,17 @@ types:
             1: dual
             2: pal
             3: dual
+  playchoice:
+    doc-ref: http://wiki.nesdev.com/w/index.php/PC10_ROM-Images
+    seq:
+      - id: inst_rom
+        size: 8192
+      - id: prom
+        type: prom
+    types:
+      prom:
+        seq:
+          - id: data
+            size: 16
+          - id: counter_out
+            size: 16

--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -8,6 +8,7 @@ meta:
 seq:
   - id: header
     type: header
+    size: 16
   - id: rom
     size-eos: true
 types:
@@ -23,15 +24,19 @@ types:
         doc: Size of CHR ROM in 8 KB units (Value 0 means the board uses CHR RAM)
       - id: f6
         type: f6
+        size: 1
       - id: f7
         type: f7
+        size: 1
       - id: prg_ram_size
         type: u1
         doc: Size of PRG RAM in 8 KB units (Value 0 infers 8 KB for compatibility; see PRG RAM circuit on nesdev.com)
       - id: f9
         type: f9
+        size: 1
       - id: f10
         type: f10
+        size: 1
         doc: this one is unofficial
       - contents: [0, 0, 0, 0, 0]
     instances:

--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -3,7 +3,7 @@ doc-ref: https://wiki.nesdev.com/w/index.php/INES
 meta:
   id: ines
   file-extension: nes
-  endian: le
+  encoding: ASCII
   license: WTFPL
 seq:
   - id: header
@@ -19,6 +19,10 @@ seq:
   - id: playchoice10
     type: playchoice10
     if: header.f7.playchoice10
+  - id: title
+    type: str
+    size-eos: true # Usually only 128/127 bytes
+    if: not _io.eof
 types:
   header:
     seq:

--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -16,9 +16,9 @@ seq:
     size: header.prg_rom_size * 16384
   - id: chr_rom
     size: header.chr_rom_size * 8192
-  - id: playchoice
-    type: playchoice
-    if: header.f7.playchoice
+  - id: playchoice10
+    type: playchoice10
+    if: header.f7.playchoice10
 types:
   header:
     seq:
@@ -85,7 +85,7 @@ types:
           - id: format
             type: b2
             doc: If equal to 2, flags 8-15 are in NES 2.0 format
-          - id: playchoice
+          - id: playchoice10
             type: b1
             doc: Determines if it made for a Nintendo PlayChoice-10 or not
           - id: vs_unisystem
@@ -128,7 +128,7 @@ types:
             1: dual
             2: pal
             3: dual
-  playchoice:
+  playchoice10:
     doc-ref: http://wiki.nesdev.com/w/index.php/PC10_ROM-Images
     seq:
       - id: inst_rom

--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -37,15 +37,15 @@ types:
     instances:
       # TODO: Add an enum for mapper. https://wiki.nesdev.com/w/index.php/List_of_mappers
       mapper:
-        value: f6.lower_nibble | (f7.upper_nibble << 4)
+        value: f6.lower_mapper | (f7.upper_mapper << 4)
         doc-ref: https://wiki.nesdev.com/w/index.php/Mapper
     types:
       f6:
         seq:
-          - id: lower_nibble
+          - id: lower_mapper
             type: b4
             doc: Lower nibble of mapper number (see https://wiki.nesdev.com/w/index.php/Mapper)
-          - id: ignore_mirror
+          - id: four_screen
             type: b1
             doc: Ignore mirroring control or above mirroring bit; instead provide four-screen VRAM
           - id: trainer
@@ -54,21 +54,21 @@ types:
           - id: has_battery_ram
             type: b1
             doc: If on the cartridge contains battery-backed PRG RAM ($6000-7FFF) or other persistent memory
-          - id: mirror
+          - id: mirroring
             type: b1
             doc: if 0, horizontal arrangement. if 1, vertical arrangement
       f7:
         seq:
-          - id: upper_nibble
+          - id: upper_mapper
             type: b4
             doc: Upper nibble of mapper number (see https://wiki.nesdev.com/w/index.php/Mapper)
           - id: format
             type: b2
             doc: If equal to 2, flags 8-15 are in NES 2.0 format
-          - id: arcade_2
+          - id: playchoice
             type: b1
             doc: Determines if it made for a Nintendo PlayChoice-10 or not
-          - id: arcade_1
+          - id: vs_unisystem
             type: b1
             doc: Determines if it is made for a Nintendo VS Unisystem or not
       f9:

--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -1,9 +1,7 @@
-# TODO: Add an enum for mapper. https://wiki.nesdev.com/w/index.php/Mapper
+doc-ref: https://wiki.nesdev.com/w/index.php/INES
 meta:
   id: ines
-  file-extension:
-    - nes
-    - ines
+  file-extension: nes
   endian: le
   license: WTFPL
 seq:
@@ -36,61 +34,62 @@ types:
         doc: this one is unofficial
       - id: zero_fill
         size: 4
-  f6:
-    seq:
-      - id: lower_nibble
-        type: b4
-        doc: Lower nibble of mapper number (see https://wiki.nesdev.com/w/index.php/Mapper)
-      - id: ignore_mirror
-        type: b1
-        doc: Ignore mirroring control or above mirroring bit; instead provide four-screen VRAM
-      - id: trainer
-        type: b1
-        doc: 512-byte trainer at $7000-$71FF (stored before PRG data)
-      - id: has_battery_ram
-        type: b1
-        doc: If on the cartridge contains battery-backed PRG RAM ($6000-7FFF) or other persistent memory
-      - id: mirror
-        type: b1
-        doc: if 0, horizontal arrangement. if 1, vertical arrangement
-  f7:
-    seq:
-      - id: upper_nibble
-        type: b4
-        doc: Upper nibble of mapper number (see https://wiki.nesdev.com/w/index.php/Mapper)
-      - id: format
-        type: b2
-        doc: If equal to 2, flags 8-15 are in NES 2.0 format
-      - id: arcade_2
-        type: b1
-        doc: Determines if it made for a Nintendo PlayChoice-10 or not
-      - id: arcade_1
-        type: b1
-        doc: Determines if it is made for a Nintendo VS Unisystem or not
-  f9:
-    seq:
-      - id: reserved
-        type: b7
-      - id: tv_system
-        type: b1
-        doc: if 0, NTSC. If 1, PAL.
-
-  f10:
-    seq:
-      - id: nothing1
-        type: b2
-      - id: bus_conflict
-        type: b1
-        doc: If 0, no bus conflicts. If 1, bus conflicts.
-      - id: prg_ram
-        type: b1
-        doc: If 0, PRG ram is present. If 1, not present.
-      - id: nothing2
-        type: b2
-      - id: tv_system
-        type: b2
-        doc: if 0, NTSC. If 2, PAL. If 1 or 3, dual compatible.
-
-instances:
-  mapper:
-    value: _root.header.f6.lower_nibble | (_root.header.f7.upper_nibble  << 4)
+    instances:
+      # TODO: Add an enum for mapper. https://wiki.nesdev.com/w/index.php/List_of_mappers
+      mapper:
+        value: f6.lower_nibble | (f7.upper_nibble << 4)
+        doc-ref: https://wiki.nesdev.com/w/index.php/Mapper
+    types:
+      f6:
+        seq:
+          - id: lower_nibble
+            type: b4
+            doc: Lower nibble of mapper number (see https://wiki.nesdev.com/w/index.php/Mapper)
+          - id: ignore_mirror
+            type: b1
+            doc: Ignore mirroring control or above mirroring bit; instead provide four-screen VRAM
+          - id: trainer
+            type: b1
+            doc: 512-byte trainer at $7000-$71FF (stored before PRG data)
+          - id: has_battery_ram
+            type: b1
+            doc: If on the cartridge contains battery-backed PRG RAM ($6000-7FFF) or other persistent memory
+          - id: mirror
+            type: b1
+            doc: if 0, horizontal arrangement. if 1, vertical arrangement
+      f7:
+        seq:
+          - id: upper_nibble
+            type: b4
+            doc: Upper nibble of mapper number (see https://wiki.nesdev.com/w/index.php/Mapper)
+          - id: format
+            type: b2
+            doc: If equal to 2, flags 8-15 are in NES 2.0 format
+          - id: arcade_2
+            type: b1
+            doc: Determines if it made for a Nintendo PlayChoice-10 or not
+          - id: arcade_1
+            type: b1
+            doc: Determines if it is made for a Nintendo VS Unisystem or not
+      f9:
+        seq:
+          - id: reserved
+            type: b7
+          - id: tv_system
+            type: b1
+            doc: if 0, NTSC. If 1, PAL.
+      f10:
+        seq:
+          - id: nothing1
+            type: b2
+          - id: bus_conflict
+            type: b1
+            doc: If 0, no bus conflicts. If 1, bus conflicts.
+          - id: prg_ram
+            type: b1
+            doc: If 0, PRG ram is present. If 1, not present.
+          - id: nothing2
+            type: b2
+          - id: tv_system
+            type: b2
+            doc: if 0, NTSC. If 2, PAL. If 1 or 3, dual compatible.

--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -129,9 +129,9 @@ types:
         enums:
           tv_system:
             0: ntsc
-            1: dual
+            1: dual1
             2: pal
-            3: dual
+            3: dual2
   playchoice10:
     doc-ref: http://wiki.nesdev.com/w/index.php/PC10_ROM-Images
     seq:

--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -13,9 +13,9 @@ seq:
     size: 512
     if: header.f6.trainer
   - id: prg_rom
-    size: header.prg_rom_size * 16384
+    size: header.len_prg_rom * 16384
   - id: chr_rom
-    size: header.chr_rom_size * 8192
+    size: header.len_chr_rom * 8192
   - id: playchoice10
     type: playchoice10
     if: header.f7.playchoice10
@@ -28,10 +28,10 @@ types:
     seq:
       - id: magic
         contents: [NES, 0x1A]
-      - id: prg_rom_size
+      - id: len_prg_rom
         type: u1
         doc: Size of PRG ROM in 16 KB units
-      - id: chr_rom_size
+      - id: len_chr_rom
         type: u1
         doc: Size of CHR ROM in 8 KB units (Value 0 means the board uses CHR RAM)
       - id: f6
@@ -40,7 +40,7 @@ types:
       - id: f7
         type: f7
         size: 1
-      - id: prg_ram_size
+      - id: len_prg_ram
         type: u1
         doc: Size of PRG RAM in 8 KB units (Value 0 infers 8 KB for compatibility; see PRG RAM circuit on nesdev.com)
       - id: f9

--- a/firmware/ines.ksy
+++ b/firmware/ines.ksy
@@ -61,7 +61,12 @@ types:
             doc: If on the cartridge contains battery-backed PRG RAM ($6000-7FFF) or other persistent memory
           - id: mirroring
             type: b1
+            enum: mirroring
             doc: if 0, horizontal arrangement. if 1, vertical arrangement
+        enums:
+          mirroring:
+            0: horizontal
+            1: vertical
       f7:
         seq:
           - id: upper_mapper
@@ -82,7 +87,12 @@ types:
           - type: b7
           - id: tv_system
             type: b1
+            enum: tv_system
             doc: if 0, NTSC. If 1, PAL.
+        enums:
+          tv_system:
+            0: ntsc
+            1: pal
       f10:
         seq:
           # TODO: enforce zero (similarly to "contents", but on bit level)
@@ -90,6 +100,7 @@ types:
           - id: bus_conflict
             type: b1
             doc: If 0, no bus conflicts. If 1, bus conflicts.
+          # TODO: 0 = true, 1 = false in this case
           - id: prg_ram
             type: b1
             doc: If 0, PRG ram is present. If 1, not present.
@@ -97,4 +108,11 @@ types:
           - type: b2
           - id: tv_system
             type: b2
+            enum: tv_system
             doc: if 0, NTSC. If 2, PAL. If 1 or 3, dual compatible.
+        enums:
+          tv_system:
+            0: ntsc
+            1: dual
+            2: pal
+            3: dual


### PR DESCRIPTION
### Overview
- Removed `meta/endian`: The specification doesn't define an endianness and doesn't require one
- Removed `ines` file extension: The specification only defines `.nes` as a valid file extension
  - This is debatable, even though the spec doesn't define it, it may be useful to define in the KSY file anyway
- Renamed a few fields for clarity
- Added enums for b1 types that don't fit true/false
- Added missing fields for the body of the ROM file

A collection of test ROMs can be found at https://wiki.nesdev.com/w/index.php/Emulator_tests. These tests are designed for emulator implementations, however they can also be used to test just the file format.