### PR TITLE
Added PAK format used by Dead Cells game

### DIFF
--- a/game/heaps_pak.ksy
+++ b/game/heaps_pak.ksy
@@ -38,10 +38,13 @@ types:
             type: u1
           - id: body
             type:
-              switch-on: flags & 0x1
+              switch-on: is_dir
               cases:
-                0: file
-                _: dir
+                true: dir
+                false: file
+        instances:
+          is_dir:
+            value: (flags & 0x1) != 0
       file:
         seq:
           - id: data_pos
@@ -60,7 +63,7 @@ types:
         seq:
           - id: num_entries
             type: u4
-          - id: entries
+          - id: content
             type: entry
             repeat: expr
             repeat-expr: num_entries

--- a/game/heaps_pak.ksy
+++ b/game/heaps_pak.ksy
@@ -35,16 +35,20 @@ types:
             type: str
             size: name_len
           - id: flags
-            type: u1
+            type: flags
           - id: body
             type:
-              switch-on: is_dir
+              switch-on: flags.is_dir
               cases:
-                true: dir
-                false: file
-        instances:
-          is_dir:
-            value: (flags & 0x1) != 0
+                true : dir
+                false : file
+        types:
+          flags:
+            seq:
+              - id: unused
+                type: b7
+              - id: is_dir
+                type: b1
       file:
         seq:
           - id: data_pos

--- a/game/heaps_pak.ksy
+++ b/game/heaps_pak.ksy
@@ -1,0 +1,66 @@
+meta:
+  id: heaps_pak
+  file-extension: pak
+  application: Games based on Haxe Game Framework "Heaps" (e.g. Dead Cells)
+  endian: le
+  license: CC0-1.0
+doc-ref: 'https://github.com/HeapsIO/heaps/blob/2bbc2b386952dfd8856c04a854bb706a52cb4b58/hxd/fmt/pak/Reader.hx'
+seq:
+  - id: header
+    type: header
+types:
+  header:
+    seq:
+      - id: magic1
+        contents: 'PAK'
+      - id: version
+        type: u1
+      - id: header_size
+        type: u4
+      - id: data_size
+        type: u4
+      - id: root_entry
+        type: entry
+        size: header_size - 16
+      - id: magic2
+        contents: 'DATA'
+    types:
+      entry:
+        doc-ref: 'https://github.com/HeapsIO/heaps/blob/2bbc2b386952dfd8856c04a854bb706a52cb4b58/hxd/fmt/pak/Data.hx'
+        seq:
+          - id: name_len
+            type: u1
+          - id: name
+            type: str
+            size: name_len
+            encoding: UTF-8
+          - id: flags
+            type: u1
+          - id: body
+            type:
+              switch-on: flags & 0x1
+              cases:
+                0: file
+                _: dir
+      file:
+        seq:
+          - id: data_pos
+            type: u4
+          - id: data_size
+            type: u4
+          # Adler32 checksum
+          - id: checksum
+            size: 4
+        instances:
+          data:
+            io: _root._io
+            pos: _root.header.header_size + data_pos
+            size: data_size
+      dir:
+        seq:
+          - id: num_entries
+            type: u4
+          - id: entries
+            type: entry
+            repeat: expr
+            repeat-expr: num_entries

--- a/game/heaps_pak.ksy
+++ b/game/heaps_pak.ksy
@@ -16,24 +16,24 @@ types:
         contents: 'PAK'
       - id: version
         type: u1
-      - id: header_size
+      - id: len_header
         type: u4
-      - id: data_size
+      - id: len_data
         type: u4
       - id: root_entry
         type: entry
-        size: header_size - 16
+        size: len_header - 16
       - id: magic2
         contents: 'DATA'
     types:
       entry:
         doc-ref: 'https://github.com/HeapsIO/heaps/blob/2bbc2b386952dfd8856c04a854bb706a52cb4b58/hxd/fmt/pak/Data.hx'
         seq:
-          - id: name_len
+          - id: len_name
             type: u1
           - id: name
             type: str
-            size: name_len
+            size: len_name
           - id: flags
             type: flags
           - id: body
@@ -51,9 +51,9 @@ types:
                 type: b1
       file:
         seq:
-          - id: data_pos
+          - id: ofs_data
             type: u4
-          - id: data_size
+          - id: len_data
             type: u4
           # Adler32 checksum
           - id: checksum
@@ -61,13 +61,13 @@ types:
         instances:
           data:
             io: _root._io
-            pos: _root.header.header_size + data_pos
-            size: data_size
+            pos: _root.header.len_header + ofs_data
+            size: len_data
       dir:
         seq:
           - id: num_entries
             type: u4
-          - id: content
+          - id: entries
             type: entry
             repeat: expr
             repeat-expr: num_entries

--- a/game/heaps_pak.ksy
+++ b/game/heaps_pak.ksy
@@ -3,7 +3,8 @@ meta:
   file-extension: pak
   application: Games based on Haxe Game Framework "Heaps" (e.g. Dead Cells)
   endian: le
-  license: CC0-1.0
+  license: MIT
+  encoding: UTF-8
 doc-ref: 'https://github.com/HeapsIO/heaps/blob/2bbc2b386952dfd8856c04a854bb706a52cb4b58/hxd/fmt/pak/Reader.hx'
 seq:
   - id: header
@@ -33,7 +34,6 @@ types:
           - id: name
             type: str
             size: name_len
-            encoding: UTF-8
           - id: flags
             type: u1
           - id: body


### PR DESCRIPTION
Added spec for the PAK format used by the Haxe Game framework [Heaps](http://heaps.io) which is used by is used by the indie game [Dead Cells](https://dead-cells.com), allowing parsing and dumping the game's resources (stored in "res.pak"):
![ksv_dead_cells](https://user-images.githubusercontent.com/1607520/31586796-ae8da55c-b1d6-11e7-8ed7-9bb4502c9c2d.png)

Let me know if something is amiss or needs more work for this pull request to be accepted.