### PR TITLE
executable/elf: add missing PAX_FLAGS segment type

### DIFF
--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -318,6 +318,7 @@ enums:
     6: phdr
     7: tls
 #    0x60000000: loos
+    0x65041580: pax_flags
     0x6fffffff: hios
 #    0x70000000: loproc
 #    0x7fffffff: hiproc


### PR DESCRIPTION
This is used by the PaX Linux security patch.  Verification can be seen at
https://pax.grsecurity.net/binutils-2.16-pt-pax-flags-200506102235.patch:

+#define PT_PAX_FLAGS	(PT_LOOS + 0x5041580) /* PaX flags */