### PR TITLE
Read GIFs till EOF block

### DIFF
--- a/image/gif.ksy
+++ b/image/gif.ksy
@@ -34,7 +34,8 @@ seq:
     doc-ref: https://www.w3.org/Graphics/GIF/spec-gif89a.txt - section 18
   - id: blocks
     type: block
-    repeat: eos
+    repeat: until
+    repeat-until: _io.eof or _.block_type == block_type::end_of_file
 types:
   header:
     doc-ref: https://www.w3.org/Graphics/GIF/spec-gif89a.txt - section 17


### PR DESCRIPTION
This PR makes the gif parser read GIFs only till EOF block. This prevents parsing errors in case a file has bytes after the EOF block.
[example gif](https://user-images.githubusercontent.com/16747982/34779270-b86ca25e-f645-11e7-80e0-1624e90ea0fb.gif)
