### PR TITLE
GPT partition table parser, will process primairy and backup sets

### DIFF
--- a/filesystem/gpt_partition_table.ksy
+++ b/filesystem/gpt_partition_table.ksy
@@ -1,21 +1,20 @@
 meta:
   id: gpt_partition_table
+  title: GPT (GUID) partition table
   endian: le
-  # License: Copyright and related rights waived via CC0 [ https://creativecommons.org/publicdomain/zero/1.0/ ]
-  # Specification taken from https://en.wikipedia.org/wiki/GUID_Partition_Table
-  #
-  # The default sector_size is 512 bytes to parse 4096 byte sectors
-  # Set both instances.sector_size.value and types.partition_header.instances.sector_size.value to 0x1000
+  license: CC0-1.0
+doc-ref: Specification taken from https://en.wikipedia.org/wiki/GUID_Partition_Table
 instances:
   sector_size:
     value: 0x200
+    # Default is 0x200 for 512 byte sectors, set to 0x1000 to parse 4096 byte sectors.
   primary:
     io: _root._io
-    pos: sector_size
+    pos: _root.sector_size
     type: partition_header
   backup:
     io: _root._io
-    pos: _io.size - sector_size
+    pos: _io.size - _root.sector_size
     type: partition_header
 types:
   partition_entry:
@@ -64,13 +63,12 @@ types:
         type: u4
       - id: crc32_array
         type: u4
-      # We don't parse the trailing zeroed space
+      # The document states "Reserved; must be zeroes for the rest of the block".
+      # It would be pointless to process a data structure that must be zeroed.
     instances:
-      sector_size:
-        value: 0x200
       entries:
         io: _root._io
-        pos: entries_start * sector_size
+        pos: entries_start * _root.sector_size
         size: entries_size
         type: partition_entry
         repeat: expr

--- a/filesystem/gpt_partition_table.ksy
+++ b/filesystem/gpt_partition_table.ksy
@@ -1,17 +1,21 @@
 meta:
   id: gpt_partition_table
   endian: le
-  # spec from https://en.wikipedia.org/wiki/GUID_Partition_Table
-  # For now we only allow for 512 byte sectors.
-  # For 4096 byte sectors, change 0x200 to 0x1000 in instances.primary.pos, instances.backup.pos and types.partition_header.instances.entries.pos 
+  # License: Copyright and related rights waived via CC0 [ https://creativecommons.org/publicdomain/zero/1.0/ ]
+  # Specification taken from https://en.wikipedia.org/wiki/GUID_Partition_Table
+  #
+  # The default sector_size is 512 bytes to parse 4096 byte sectors
+  # Set both instances.sector_size.value and types.partition_header.instances.sector_size.value to 0x1000
 instances:
+  sector_size:
+    value: 0x200
   primary:
     io: _root._io
-    pos: 0x200
+    pos: sector_size
     type: partition_header
   backup:
     io: _root._io
-    pos: _io.size - 0x200
+    pos: _io.size - sector_size
     type: partition_header
 types:
   partition_entry:
@@ -62,9 +66,11 @@ types:
         type: u4
       # We don't parse the trailing zeroed space
     instances:
+      sector_size:
+        value: 0x200
       entries:
         io: _root._io
-        pos: entries_start * 0x200
+        pos: entries_start * sector_size
         size: entries_size
         type: partition_entry
         repeat: expr

--- a/filesystem/gpt_partition_table.ksy
+++ b/filesystem/gpt_partition_table.ksy
@@ -1,0 +1,72 @@
+meta:
+  id: gpt_partition_table
+  endian: le
+  # spec from https://en.wikipedia.org/wiki/GUID_Partition_Table
+  # For now we only allow for 512 byte sectors.
+  # For 4096 byte sectors, change 0x200 to 0x1000 in instances.primary.pos, instances.backup.pos and types.partition_header.instances.entries.pos 
+instances:
+  primary:
+    io: _root._io
+    pos: 0x200
+    type: partition_header
+  backup:
+    io: _root._io
+    pos: _io.size - 0x200
+    type: partition_header
+types:
+  partition_entry:
+    seq:
+      - id: type_guid
+        size: 0x10
+      - id: guid
+        size: 0x10
+      - id: first_lba
+        type: u8
+      - id: last_lba
+        type: u8
+      - id: attributes
+        type: u8
+      - id: name
+        type: str
+        encoding: UTF-16LE
+        size: 0x48
+  partition_header:
+    seq:
+      - id: signature
+        contents: [0x45, 0x46, 0x49, 0x20, 0x50, 0x41, 0x52, 0x54]
+      - id: revision
+        type: u4
+      - id: header_size
+        type: u4
+      - id: crc32_header
+        type: u4
+      - id: reserved
+        type: u4
+      - id: current_lba
+        type: u8
+      - id: backup_lba
+        type: u8
+      - id: first_usable_lba
+        type: u8
+      - id: last_usable_lba
+        type: u8
+      - id: disk_guid
+        size: 0x10
+      - id: entries_start
+        type: u8
+      - id: entries_count
+        type: u4
+      - id: entries_size
+        type: u4
+      - id: crc32_array
+        type: u4
+      # We don't parse the trailing zeroed space
+    instances:
+      entries:
+        io: _root._io
+        pos: entries_start * 0x200
+        size: entries_size
+        type: partition_entry
+        repeat: expr
+        repeat-expr: entries_count
+


### PR DESCRIPTION
It works on 512 byte sector size only.