### PR TITLE
[network/icmp_packet] add missing data field

### DIFF
--- a/network/icmp_packet.ksy
+++ b/network/icmp_packet.ksy
@@ -73,3 +73,5 @@ types:
         type: u2
       - id: seq_num
         type: u2
+      - id: data
+        size-eos: true


### PR DESCRIPTION
The ICMP echo messages are missing the final data field. The size information is in the IP header, so we just read until the end of the substream.

Thanks again for the fantastic project! 🍰 