### PR TITLE
Add TR-DOS filesystem format

### DIFF
--- a/filesystem/trd.ksy
+++ b/filesystem/trd.ksy
@@ -36,6 +36,9 @@ types:
   file:
     seq:
       - id: name
+        # It uses custom type due to limitation of streams: there's no way to
+        # extract first byte from byte array directly
+        type: filename
         size: 8
       - id: extension
         type: u1
@@ -54,14 +57,10 @@ types:
       - id: starting_track
         type: u1
     instances:
-      name_first_byte:
-        pos: 0
-        type: u1
-        io: name._io
       is_deleted:
-        value: name_first_byte == 0x01
+        value: name.first_byte == 0x01
       is_terminator:
-        value: name_first_byte == 0x00
+        value: name.first_byte == 0x00
       contents:
         pos: starting_track * 256 * 16 + starting_sector * 256
         size: length_sectors * 256
@@ -138,6 +137,15 @@ types:
         value: "disk_type.to_i & 0x01 != 0 ? 40 : 80"
       num_sides:
         value: "disk_type.to_i & 0x08 != 0 ? 1 : 2"
+  filename:
+    seq:
+      - id: name
+        size: 8
+    instances:
+      first_byte:
+        pos: 0
+        type: u1
+
 enums:
   disk_type:
     0x16: type_80_tracks_double_side

--- a/filesystem/trd.ksy
+++ b/filesystem/trd.ksy
@@ -1,0 +1,138 @@
+meta:
+  id: tr_dos_image
+  file-extension: trd
+  title: "TR-DOS flat-file disk image"
+  license: CC0-1.0
+  # It's extended ascii (with ZX Spectrum Basic tokens, UDG, etc), but
+  # "unknown-8bit" can't be used for some reason
+  encoding: ascii
+  endian: le
+doc: |
+  .trd file is a raw dump of TR-DOS (ZX-Spectrum) floppy. .trd files are
+  headerless and contain consequent "logical tracks", each logical track
+  consists of 16 256-byte sectors.
+
+  Logical tracks are defined the same way as used by TR-DOS: for single-side
+  floppies it's just a physical track number, for two-side floppies sides are
+  interleaved, i.e. logical_track_num = (physical_track_num << 1) | side
+
+  So, this format definition is more for TR-DOS filesystem than for .trd files,
+  which are formatless.
+
+  Strings (file names, disk label, disk password) are padded with spaces and use
+  ZX Spectrum character set, including UDGs, block drawing chars and Basic
+  tokens. ASCII range is mostly standard ASCII, with few characters (^, `, DEL)
+  replaced with (up arrow, pound, copyright symbol).
+seq:
+  - id: files
+    type: file
+    repeat: until
+    # After 128 files there is disk info entry, which also has 0x00 terminator
+    # in the same position as file name. So usually even with 128 files you can
+    # just read until 0x00.
+    repeat-until: _.is_terminator
+instances:
+  volume_info:
+    pos: 0x800
+    type: volume_info
+types:
+  file:
+    seq:
+      - id: name
+        type: str
+        size: 8
+      - id: extension
+        type: str
+        size: 1
+
+      - id: program_and_data_length
+        type: u2
+        if: extension == "B"
+      - id: start_address
+        doc: Default memory address to load this byte array into
+        type: u2
+        if: extension == "C"
+      - id: print_extent_num
+        type: u1
+        if: extension == "#"
+      - id: print_unused
+        type: u1
+        if: extension == "#"
+      - id: length1_unused
+        size: 2
+        if: extension != "B" and extension != "C" and extension != "#"
+
+      - id: length
+        type: u2
+        doc: |
+          For "B" type, it's length of program only, use
+          program_and_data_length for full length. For other types it's length
+          in bytes
+      - id: length_sectors
+        type: u1
+      - id: starting_sector
+        type: u1
+      - id: starting_track
+        type: u1
+    instances:
+      is_deleted:
+        value: name.substring(0, 1) == "\1"
+      is_terminator:
+        value: name.substring(0, 1) == "\0"
+      contents:
+        pos: starting_track * 256 * 16 + starting_sector * 256
+        size: length_sectors * 256
+  volume_info:
+    seq:
+      # This is 0x00 at the same position as first character of filename in
+      # file entries for convenience. When disk has 128 files, it acts as
+      # "last file" terminator.
+      - id: catalog_end
+        contents: [0]
+      - id: unused
+        size: 224
+      - id: first_free_sector_sector
+        type: u1
+      - id: first_free_sector_track
+        doc: |
+          track number is logical, for double-sided disks it's
+          (physical_track << 1) | side, the same way that tracks are stored
+          sequentially in .trd file
+        type: u1
+      - id: disk_type
+        type: u1
+        enum: disk_type
+      - id: number_of_files
+        doc: |
+          Number of non-deleted files. Directory can have more than
+          number_of_files entries due to deleted files
+        type: u1
+      - id: number_of_free_sectors
+        type: u2
+      - id: tr_dos_id
+        contents: [0x10]
+      - id: unused_2
+        size: 2
+      - id: password
+        type: str
+        size: 9
+      - id: unused_3
+        size: 1
+      - id: number_of_deleted_files
+        type: u1
+      - id: label
+        type: str
+        size: 8
+      - id: unused_4
+        size: 3
+    instances:
+      number_of_tracks:
+        value: "disk_type.to_i & 0x01 != 0 ? 40 : 80"
+      number_of_sides:
+        value: "disk_type.to_i & 0x08 != 0 ? 1 : 2"
+enums:
+  disk_type:
+    0x16: type_80_tracks_double_side
+    0x17: type_40_tracks_double_side
+    0x18: type_80_tracks_single_side
+    0x19: type_40_tracks_single_side

--- a/filesystem/trd.ksy
+++ b/filesystem/trd.ksy
@@ -113,12 +113,12 @@ types:
       - id: disk_type
         type: u1
         enum: disk_type
-      - id: number_of_files
+      - id: num_files
         doc: |
           Number of non-deleted files. Directory can have more than
           number_of_files entries due to deleted files
         type: u1
-      - id: number_of_free_sectors
+      - id: num_free_sectors
         type: u2
       - id: tr_dos_id
         contents: [0x10]
@@ -129,7 +129,7 @@ types:
         size: 9
       - id: unused_3
         size: 1
-      - id: number_of_deleted_files
+      - id: num_deleted_files
         type: u1
       - id: label
         type: str
@@ -137,9 +137,9 @@ types:
       - id: unused_4
         size: 3
     instances:
-      number_of_tracks:
+      num_tracks:
         value: "disk_type.to_i & 0x01 != 0 ? 40 : 80"
-      number_of_sides:
+      num_sides:
         value: "disk_type.to_i & 0x08 != 0 ? 1 : 2"
 enums:
   disk_type:

--- a/filesystem/trd.ksy
+++ b/filesystem/trd.ksy
@@ -20,6 +20,9 @@ doc: |
   ZX Spectrum character set, including UDGs, block drawing chars and Basic
   tokens. ASCII range is mostly standard ASCII, with few characters (^, `, DEL)
   replaced with (up arrow, pound, copyright symbol).
+
+  .trd file can be smaller than actual floppy disk, if last logical tracks are
+  empty (contain no file data) they can be omitted.
 seq:
   - id: files
     type: file

--- a/filesystem/trd.ksy
+++ b/filesystem/trd.ksy
@@ -44,30 +44,14 @@ types:
       - id: extension
         type: str
         size: 1
-
-      - id: program_and_data_length
-        type: u2
-        if: extension == "B"
-      - id: start_address
-        doc: Default memory address to load this byte array into
-        type: u2
-        if: extension == "C"
-      - id: print_extent_num
-        type: u1
-        if: extension == "#"
-      - id: print_unused
-        type: u1
-        if: extension == "#"
-      - id: length1_unused
-        size: 2
-        if: extension != "B" and extension != "C" and extension != "#"
-
-      - id: length
-        type: u2
-        doc: |
-          For "B" type, it's length of program only, use
-          program_and_data_length for full length. For other types it's length
-          in bytes
+      - id: position_and_length
+        type:
+          switch-on: extension
+          cases:
+            '"B"': position_and_length_basic
+            '"C"': position_and_length_code
+            '"#"': position_and_length_print
+            _: position_and_length_generic
       - id: length_sectors
         type: u1
       - id: starting_sector
@@ -82,6 +66,33 @@ types:
       contents:
         pos: starting_track * 256 * 16 + starting_sector * 256
         size: length_sectors * 256
+  position_and_length_basic:
+    seq:
+      - id: program_and_data_length
+        type: u2
+      - id: program_length
+        type: u2
+  position_and_length_code:
+    seq:
+      - id: start_address
+        type: u2
+        doc: Default memory address to load this byte array into
+      - id: length
+        type: u2
+  position_and_length_print:
+    seq:
+      - id: extent_no
+        type: u1
+      - id: reserved
+        type: u1
+      - id: length
+        type: u2
+  position_and_length_generic: # used for standard 'D' type and unknown types
+    seq:
+      - id: reserved
+        type: u2
+      - id: length
+        type: u2
   volume_info:
     seq:
       # This is 0x00 at the same position as first character of filename in


### PR DESCRIPTION
[TR-DOS](https://en.wikipedia.org/wiki/TR-DOS) is operating system for ZX-Spectrum computer with Beta Disc floppy drive interface. It might be not very popular in the west, but was especially popular in USSR and early post-USSR due to availability of Soviet clones of Beta Disc and WD1793.

`.trd` files are sector-by-sector raw floppy disk dumps (similar to PC floppy `.img` or copies of `/dev/fd0`), so this format file describes actual TR-DOS filesystem rather than `.trd` format itself.

~May not compile for `graphviz` and `go` right now due to https://github.com/kaitai-io/kaitai_struct/issues/491~ (removed `substring` because changed to bytes)

- [x] figure out how to extract first byte from filename
- [x] `List(ArraySeq(IntNum(0))) (of class io.kaitai.struct.exprlang.Ast$expr$List)` for `go` target — This is probably ok, Go support is experimental