### PR TITLE
TrueType 'post' goes to eos.

### DIFF
--- a/font/ttf.ksy
+++ b/font/ttf.ksy
@@ -880,8 +880,7 @@ types:
             repeat-expr: number_of_glyphs
           - id: glyph_names
             type: pascal_string
-            repeat: until
-            repeat-until: _.length == 0
+            repeat: eos
     seq:
       - id: format
         type: fixed


### PR DESCRIPTION
The current implementation assumes that there will be a zero length
pascal string at the end of a version 2 'post' table. There is no such
requirement and this will fail to load a font which happens to have such
a table which ends on exactly a four byte boundary.

Note that FreeType determines the number of pascal strings to read by
iterating over the glyph name index values and selecting the highest
index. However, this only shows used strings and not all of the data.