### PR TITLE
Added missing exif field types

### DIFF
--- a/image/exif_be.ksy
+++ b/image/exif_be.ksy
@@ -57,9 +57,9 @@ types:
         3: word
         4: dword
         5: rational
-	7: undefined
-	9: slong
-	10: srational
+        7: undefined
+        9: slong
+        10: srational
       tag_enum:
         0x0100: image_width
         0x0101: image_height

--- a/image/exif_be.ksy
+++ b/image/exif_be.ksy
@@ -57,6 +57,9 @@ types:
         3: word
         4: dword
         5: rational
+	7: undefined
+	9: slong
+	10: srational
       tag_enum:
         0x0100: image_width
         0x0101: image_height

--- a/image/exif_le.ksy
+++ b/image/exif_le.ksy
@@ -57,9 +57,9 @@ types:
         3: word
         4: dword
         5: rational
-	7: undefined
-	9: slong
-	10: srational
+        7: undefined
+        9: slong
+        10: srational
       tag_enum:
         0x0100: image_width
         0x0101: image_height

--- a/image/exif_le.ksy
+++ b/image/exif_le.ksy
@@ -57,6 +57,9 @@ types:
         3: word
         4: dword
         5: rational
+	7: undefined
+	9: slong
+	10: srational
       tag_enum:
         0x0100: image_width
         0x0101: image_height


### PR DESCRIPTION
Added missing field types in field_type_enum of exif files, which were missing according to the official spec: https://www.exif.org/Exif2-2.PDF. Addresses https://github.com/mitmproxy/mitmproxy/issues/3360#issue-373534204 .