### PR TITLE
little fixes

### DIFF
--- a/image/gif.ksy
+++ b/image/gif.ksy
@@ -18,7 +18,7 @@ doc: |
 
   GIF format allows encoding of palette-based images up to 256 colors
   (each of the colors can be chosen from a 24-bit RGB
-  colorspace). Image data stream uses LZW (Lempel–Ziv–Welch) lossless
+  colorspace). Image data stream uses LZW (Lempel-Ziv-Welch) lossless
   compression.
 
   Over the years, several version of the format were published and

--- a/image/wmf.ksy
+++ b/image/wmf.ksy
@@ -252,7 +252,7 @@ enums:
     0x0003: masknotpen
     0x0004: notcopypen
     0x0005: maskpennot
-    0x0006: not
+    0x0006: not_
     0x0007: xorpen
     0x0008: notmaskpen
     0x0009: maskpen


### PR DESCRIPTION
the gif.ksy one looks like nothing is changed thru github, but those dashes were made of some strange 0xE2 byte which, after compilation, would end up in compiled files and the python interpreter would complain

the wmf.ksy one would compile and have an enum named "not" which is a reserved python keyword and thereful wouldn't run - changing the .ksy works but doesnt feel right, feel free to reject this one