### PR TITLE
macOS '.DS_Store' files

### DIFF
--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -17,9 +17,9 @@ seq:
     type: buddy_allocator_header
 instances:
   buddy_allocator_body:
+    pos: buddy_allocator_header.ofs_bookkeeping_info_block + 4
     type: buddy_allocator_body
     size: buddy_allocator_header.size_bookkeeping_info_block
-    pos: buddy_allocator_header.ofs_bookkeeping_info_block + 4
 types:
   buddy_allocator_header:
     seq:
@@ -62,8 +62,8 @@ types:
     instances:
       directories:
         io: _root._io
-        size: 1 << block_addresses[directory_entries[0].block_id] & 0x1f
         pos: (block_addresses[directory_entries[0].block_id] >> 0x05 << 0x05) + 4
+        size: 1 << block_addresses[directory_entries[0].block_id] & 0x1f
         type: master_block
         repeat: expr
         repeat-expr: directory_count

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -61,6 +61,26 @@ types:
         repeat: expr
         repeat-expr: num_free_lists
     types:
+      block_descriptor:
+        seq:
+          - id: address_raw
+            type: u4
+        instances:
+          mask:
+            value: 0x1f
+          offset:
+            value: (address_raw & ~mask) + 4
+          size:
+            value: 1 << address_raw & mask
+      directory_entry:
+        seq:
+          - id: len_name
+            type: u1
+          - id: name
+            size: len_name
+            type: str
+          - id: block_id
+            type: u4
       free_list:
         seq:
           - id: counter
@@ -80,26 +100,6 @@ types:
         repeat: expr
         repeat-expr: num_directories
         doc: Master blocks of the different B-trees
-  block_descriptor:
-    seq:
-      - id: address_raw
-        type: u4
-    instances:
-      mask:
-        value: 0x1f
-      offset:
-        value: (address_raw & ~mask) + 4
-      size:
-        value: 1 << address_raw & mask
-  directory_entry:
-    seq:
-      - id: len_name
-        type: u1
-      - id: name
-        size: len_name
-        type: str
-      - id: block_id
-        type: u4
   master_block_ref:
     params:
       - id: idx

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -19,18 +19,18 @@ instances:
   buddy_allocator_body:
     type: buddy_allocator_body
     size: buddy_allocator_header.size_bookkeeping_info_block
-    pos: buddy_allocator_header.offset_bookkeeping_info_block + 4
+    pos: buddy_allocator_header.ofs_bookkeeping_info_block + 4
 types:
   buddy_allocator_header:
     seq:
       - id: magic
         contents: [0x42, 0x75, 0x64, 0x31]
         doc: Magic number 'Bud1'
-      - id: offset_bookkeeping_info_block
+      - id: ofs_bookkeeping_info_block
         type: u4
       - id: size_bookkeeping_info_block
         type: u4
-      - id: copy_offset_bookkeeping_info_block
+      - id: copy_ofs_bookkeeping_info_block
         type: u4
         doc: Needs to match 'offset_bookkeeping_info_block'
       - size: 16

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -18,8 +18,8 @@ seq:
 instances:
   buddy_allocator_body:
     pos: buddy_allocator_header.ofs_bookkeeping_info_block + 4
-    type: buddy_allocator_body
     size: buddy_allocator_header.len_bookkeeping_info_block
+    type: buddy_allocator_body
 types:
   buddy_allocator_header:
     seq:

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -62,9 +62,7 @@ types:
     instances:
       directories:
         io: _root._io
-        pos: (block_addresses[directory_entries[0].block_id] >> 0x05 << 0x05) + 4
-        size: 1 << block_addresses[directory_entries[0].block_id] & 0x1f
-        type: master_block
+        type: master_block_ref(_index)
         repeat: expr
         repeat-expr: num_directories
         doc: Master blocks of the different B-trees
@@ -86,6 +84,15 @@ types:
         type: u4
         repeat: expr
         repeat-expr: counter
+  master_block_ref:
+    params:
+      - id: idx
+        type: u8
+    instances:
+      master_block:
+        pos: (_parent.block_addresses[_parent.directory_entries[idx].block_id] >> 0x05 << 0x05) + 4
+        size: 1 << _parent.block_addresses[_parent.directory_entries[idx].block_id] & 0x1f
+        type: master_block
   master_block:
     seq:
       - id: block_id

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -1,9 +1,13 @@
 meta:
   id: macos_ds_store
-  endian: be
-  ks-version: 0.8
+  title: macOS '.DS_Store' format
   license: CC-BY-SA-4.0
+  ks-version: 0.8
+  endian: be
+doc: |
+  Apple macOS '.DS_Store' file format.
 doc-ref: |
+  https://en.wikipedia.org/wiki/.DS_Store
   https://metacpan.org/pod/distribution/Mac-Finder-DSStore/DSStoreFormat.pod
   https://0day.work/parsing-the-ds_store-file-format
 seq:

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -1,5 +1,5 @@
 meta:
-  id: macos_ds_store
+  id: ds_store
   title: macOS '.DS_Store' format
   license: CC-BY-SA-4.0
   ks-version: 0.8

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -72,10 +72,12 @@ types:
       - id: address_raw
         type: u4
     instances:
+      mask:
+        value: 0x1f
       offset:
-        value: (address_raw & ~0x1f) + 4
+        value: (address_raw & ~mask) + 4
       size:
-        value: 1 << address_raw & 0x1f
+        value: 1 << address_raw & mask
   directory_entry:
     seq:
       - id: len_name

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -33,15 +33,15 @@ types:
       - id: copy_offset_bookkeeping_info_block
         type: u4
         doc: Needs to match 'offset_bookkeeping_info_block'
-      - id: unused_block
-        size: 16
+      - size: 16
+        doc: Unused block
   buddy_allocator_body:
     seq:
       - id: block_count
         type: u4
         doc: Number of blocks in the allocated-blocks list
-      - id: unknown_field
-        size: 4
+      - size: 4
+        doc: Unknown field
       - id: block_addresses
         type: u4
         repeat: expr
@@ -100,8 +100,8 @@ types:
       - id: num_nodes
         type: u4
         doc: Number of nodes in the tree
-      - id: unknown
-        type: u4
+      - type: u4
+        doc: Unknown field
     instances:
       root_block:
         io: _root._io

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -104,32 +104,33 @@ types:
     params:
       - id: idx
         type: u8
+    types:
+      master_block:
+        seq:
+          - id: block_id
+            type: u4
+            doc: Block number of the B-tree's root node
+          - id: num_internal_nodes
+            type: u4
+            doc: Number of internal node levels
+          - id: num_records
+            type: u4
+            doc: Number of records in the tree
+          - id: num_nodes
+            type: u4
+            doc: Number of nodes in the tree
+          - type: u4
+            doc: Unknown field
+        instances:
+          root_block:
+            io: _root._io
+            pos: _root.buddy_allocator_body.block_addresses[block_id].offset
+            type: block
     instances:
       master_block:
         pos: _parent.block_addresses[_parent.directory_entries[idx].block_id].offset
         size: _parent.block_addresses[_parent.directory_entries[idx].block_id].size
         type: master_block
-  master_block:
-    seq:
-      - id: block_id
-        type: u4
-        doc: Block number of the B-tree's root node
-      - id: num_internal_nodes
-        type: u4
-        doc: Number of internal node levels
-      - id: num_records
-        type: u4
-        doc: Number of records in the tree
-      - id: num_nodes
-        type: u4
-        doc: Number of nodes in the tree
-      - type: u4
-        doc: Unknown field
-    instances:
-      root_block:
-        io: _root._io
-        pos: _root.buddy_allocator_body.block_addresses[block_id].offset
-        type: block
   block:
     seq:
       - id: mode

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -26,36 +26,38 @@ types:
     seq:
       - id: magic
         contents: ["Bud1"]
-        doc: Magic number 'Bud1'
+        doc: Magic number 'Bud1'.
       - id: ofs_bookkeeping_info_block
         type: u4
       - id: len_bookkeeping_info_block
         type: u4
       - id: copy_ofs_bookkeeping_info_block
         type: u4
-        doc: Needs to match 'offset_bookkeeping_info_block'
+        doc: Needs to match 'offset_bookkeeping_info_block'.
       - size: 16
-        doc: Unused block
+        doc: |
+          Unused field which might simply be the unused space at the end of the block,
+          since the minimum allocation size is 32 bytes.
   buddy_allocator_body:
     seq:
       - id: num_blocks
         type: u4
-        doc: Number of blocks in the allocated-blocks list
+        doc: Number of blocks in the allocated-blocks list.
       - size: 4
-        doc: Unknown field
+        doc: Unknown field which appears to always be 0.
       - id: block_addresses
         type: block_descriptor
         repeat: expr
         repeat-expr: num_block_addresses
-        doc: Addresses of the different blocks
+        doc: Addresses of the different blocks.
       - id: num_directories
         type: u4
-        doc: Indicates the number of directory entries
+        doc: Indicates the number of directory entries.
       - id: directory_entries
         type: directory_entry
         repeat: expr
         repeat-expr: num_directories
-        doc: Each directory is an independent B-tree
+        doc: Each directory is an independent B-tree.
       - id: free_lists
         type: free_list
         repeat: expr
@@ -99,7 +101,7 @@ types:
         type: master_block_ref(_index)
         repeat: expr
         repeat-expr: num_directories
-        doc: Master blocks of the different B-trees
+        doc: Master blocks of the different B-trees.
   master_block_ref:
     params:
       - id: idx
@@ -109,18 +111,18 @@ types:
         seq:
           - id: block_id
             type: u4
-            doc: Block number of the B-tree's root node
+            doc: Block number of the B-tree's root node.
           - id: num_internal_nodes
             type: u4
-            doc: Number of internal node levels
+            doc: Number of internal node levels.
           - id: num_records
             type: u4
-            doc: Number of records in the tree
+            doc: Number of records in the tree.
           - id: num_nodes
             type: u4
-            doc: Number of nodes in the tree
+            doc: Number of nodes in the tree.
           - type: u4
-            doc: Unknown field
+            doc: Always 0x1000, probably the B-tree node page size.
         instances:
           root_block:
             io: _root._io
@@ -135,10 +137,10 @@ types:
     seq:
       - id: mode
         type: u4
-        doc: If mode is 0, this is a leaf node, otherwise it is an internal node
+        doc: If mode is 0, this is a leaf node, otherwise it is an internal node.
       - id: counter
         type: u4
-        doc: Number of records or number of block id + record pairs
+        doc: Number of records or number of block id + record pairs.
       - id: data
         type: block_data(mode)
         repeat: expr
@@ -149,18 +151,18 @@ types:
         pos: _root.buddy_allocator_body.block_addresses[mode].offset
         type: block
         if: mode > 0
-        doc: Rightmost child block pointer
+        doc: Rightmost child block pointer.
   record:
     seq:
       - id: filename
         type: ustr
       - id: structure_type
         type: four_char_code
-        doc: Description of the entry's property
+        doc: Description of the entry's property.
       - id: data_type
         size: 4
         type: str
-        doc: Data type of the value
+        doc: Data type of the value.
       - id: value
         type:
           switch-on: data_type

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -19,7 +19,7 @@ instances:
   buddy_allocator_body:
     pos: buddy_allocator_header.ofs_bookkeeping_info_block + 4
     type: buddy_allocator_body
-    size: buddy_allocator_header.size_bookkeeping_info_block
+    size: buddy_allocator_header.len_bookkeeping_info_block
 types:
   buddy_allocator_header:
     seq:
@@ -28,7 +28,7 @@ types:
         doc: Magic number 'Bud1'
       - id: ofs_bookkeeping_info_block
         type: u4
-      - id: size_bookkeeping_info_block
+      - id: len_bookkeeping_info_block
         type: u4
       - id: copy_ofs_bookkeeping_info_block
         type: u4
@@ -37,7 +37,7 @@ types:
         doc: Unused block
   buddy_allocator_body:
     seq:
-      - id: block_count
+      - id: num_blocks
         type: u4
         doc: Number of blocks in the allocated-blocks list
       - size: 4
@@ -47,13 +47,13 @@ types:
         repeat: expr
         repeat-expr: 256
         doc: Addresses of the different blocks
-      - id: directory_count
+      - id: num_directories
         type: u4
         doc: Indicates the number of directory entries
       - id: directory_entries
         type: directory_entry
         repeat: expr
-        repeat-expr: directory_count
+        repeat-expr: num_directories
         doc: Each directory is an independent B-tree
       - id: free_lists
         type: free_list
@@ -66,14 +66,14 @@ types:
         size: 1 << block_addresses[directory_entries[0].block_id] & 0x1f
         type: master_block
         repeat: expr
-        repeat-expr: directory_count
+        repeat-expr: num_directories
         doc: Master blocks of the different B-trees
   directory_entry:
     seq:
-      - id: name_len
+      - id: len_name
         type: u1
       - id: name
-        size: name_len
+        size: len_name
         type: str
         encoding: UTF-8
       - id: block_id
@@ -112,13 +112,13 @@ types:
       - id: mode
         type: u4
         doc: If mode is 0, this is a leaf node, otherwise it is an internal node
-      - id: count
+      - id: counter
         type: u4
         doc: Number of records or number of block id + record pairs
       - id: data
         type: block_data(mode)
         repeat: expr
-        repeat-expr: count
+        repeat-expr: counter
     instances:
       rightmost_block:
         io: _root._io

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -148,6 +148,67 @@ types:
         type: block_data(mode)
         repeat: expr
         repeat-expr: counter
+    types:
+      block_data:
+        params:
+          - id: mode
+            type: u4
+        seq:
+          - id: block_id
+            type: u4
+            if: mode > 0
+          - id: record
+            type: record
+        types:
+          record:
+            seq:
+              - id: filename
+                type: ustr
+              - id: structure_type
+                type: four_char_code
+                doc: Description of the entry's property.
+              - id: data_type
+                size: 4
+                type: str
+                doc: Data type of the value.
+              - id: value
+                type:
+                  switch-on: data_type
+                  cases:
+                    '"long"': u4
+                    '"shor"': u4
+                    '"bool"': u1
+                    '"blob"': record_blob
+                    '"type"': four_char_code
+                    '"ustr"': ustr
+                    '"comp"': u8
+                    '"dutc"': u8
+            types:
+              record_blob:
+                seq:
+                  - id: length
+                    type: u4
+                  - id: value
+                    size: length
+              ustr:
+                seq:
+                  - id: length
+                    type: u4
+                  - id: value
+                    size: 2 * length
+                    type: str
+                    encoding: UTF-16BE
+              four_char_code:
+                seq:
+                  - id: value
+                    size: 4
+                    type: str
+        instances:
+          block:
+            io: _root._io
+            pos: _root.buddy_allocator_body.block_addresses[block_id].offset
+            type: block
+            if: mode > 0
     instances:
       rightmost_block:
         io: _root._io
@@ -155,61 +216,3 @@ types:
         type: block
         if: mode > 0
         doc: Rightmost child block pointer.
-  record:
-    seq:
-      - id: filename
-        type: ustr
-      - id: structure_type
-        type: four_char_code
-        doc: Description of the entry's property.
-      - id: data_type
-        size: 4
-        type: str
-        doc: Data type of the value.
-      - id: value
-        type:
-          switch-on: data_type
-          cases:
-            '"long"': u4
-            '"shor"': u4
-            '"bool"': u1
-            '"blob"': record_blob
-            '"type"': four_char_code
-            '"ustr"': ustr
-            '"comp"': u8
-            '"dutc"': u8
-  block_data:
-    params:
-      - id: mode
-        type: u4
-    seq:
-      - id: block_id
-        type: u4
-        if: mode > 0
-      - id: record
-        type: record
-    instances:
-      block:
-        io: _root._io
-        pos: _root.buddy_allocator_body.block_addresses[block_id].offset
-        type: block
-        if: mode > 0
-  record_blob:
-    seq:
-      - id: length
-        type: u4
-      - id: value
-        size: length
-  ustr:
-    seq:
-      - id: length
-        type: u4
-      - id: value
-        size: 2 * length
-        type: str
-        encoding: UTF-16BE
-  four_char_code:
-    seq:
-      - id: value
-        size: 4
-        type: str

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -1,0 +1,168 @@
+meta:
+  id: macos_ds_store
+  endian: be
+  ks-version: 0.8
+  license: CC-BY-SA-4.0
+doc-ref: |
+  https://metacpan.org/pod/distribution/Mac-Finder-DSStore/DSStoreFormat.pod
+  https://0day.work/parsing-the-ds_store-file-format
+seq:
+  - id: alignment
+    contents: [0x00, 0x00, 0x00, 0x01]
+  - id: buddy_allocator_header
+    type: buddy_allocator_header
+instances:
+  buddy_allocator_body:
+    type: buddy_allocator_body
+    pos: buddy_allocator_header.offset_bookkeeping_info_block + 4
+    size: buddy_allocator_header.size_bookkeeping_info_block
+types:
+  buddy_allocator_header:
+    seq:
+      - id: magic
+        contents: [0x42, 0x75, 0x64, 0x31]
+      - id: offset_bookkeeping_info_block
+        type: u4
+      - id: size_bookkeeping_info_block
+        type: u4
+      - id: copy_offset_bookkeeping_info_block
+        type: u4
+      - id: unused_block
+        size: 16
+  buddy_allocator_body:
+    seq:
+      - id: block_count
+        type: u4
+      - id: unknown_field
+        size: 4
+      - id: block_addresses
+        type: u4
+        repeat: expr
+        repeat-expr: 256
+      - id: directory_count
+        type: u4
+      - id: directory_entries
+        type: directory_entry
+        repeat: expr
+        repeat-expr: directory_count
+      - id: free_lists
+        type: free_list
+        repeat: expr
+        repeat-expr: 32
+    instances:
+      directories:
+        io: _root._io
+        type: master_block
+        repeat: expr
+        repeat-expr: directory_count
+        pos: (block_addresses[directory_entries[0].block_id] >> 0x05 << 0x05) + 4
+        size: 1 << block_addresses[directory_entries[0].block_id] & 0x1f
+  directory_entry:
+    seq:
+      - id: name_len
+        type: u1
+      - id: name
+        type: str
+        encoding: UTF-8
+        size: name_len
+      - id: block_id
+        type: u4
+  free_list:
+    seq:
+      - id: counter
+        type: u4
+      - id: offsets
+        type: u4
+        repeat: expr
+        repeat-expr: counter
+  master_block:
+    seq:
+      - id: block_id
+        type: u4
+      - id: num_internal_nodes
+        type: u4
+      - id: num_records
+        type: u4
+      - id: num_nodes
+        type: u4
+      - id: unknown
+        type: u4
+    instances:
+      block:
+        io: _root._io
+        type: block
+        pos: (_root.buddy_allocator_body.block_addresses[block_id] >> 0x05 << 0x05) + 4
+  block:
+    seq:
+      - id: mode
+        type: u4
+      - id: count
+        type: u4
+      - id: data
+        type: block_data(mode)
+        repeat: expr
+        repeat-expr: count
+    instances:
+      block:
+        io: _root._io
+        type: block
+        if: mode > 0
+        pos: (_root.buddy_allocator_body.block_addresses[mode] >> 0x05 << 0x05) + 4
+  record:
+    seq:
+      - id: filename
+        type: ustr
+      - id: structure_type
+        type: four_char_code
+      - id: data_type
+        type: str
+        encoding: UTF-8
+        size: 4
+      - id: value
+        type:
+          switch-on: data_type
+          cases:
+            '"long"': u4
+            '"shor"': u4
+            '"bool"': u1
+            '"blob"': record_blob
+            '"type"': four_char_code
+            '"ustr"': ustr
+            '"comp"': u8
+            '"dutc"': u8
+  block_data:
+    params:
+      - id: mode
+        type: u4
+    seq:
+      - id: block_id
+        type: u4
+        if: mode > 0
+      - id: record
+        type: record
+    instances:
+      block:
+        io: _root._io
+        type: block
+        if: mode > 0
+        pos: (_root.buddy_allocator_body.block_addresses[block_id] >> 0x05 << 0x05) + 4
+  record_blob:
+    seq:
+      - id: length
+        type: u4
+      - id: value
+        size: length
+  ustr:
+    seq:
+      - id: length
+        type: u4
+      - id: value
+        type: str
+        encoding: UTF-16BE
+        size: 2 * length
+  four_char_code:
+    seq:
+      - id: value
+        type: str
+        encoding: UTF-8
+        size: 4

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -103,7 +103,7 @@ types:
       - id: unknown
         type: u4
     instances:
-      block:
+      root_block:
         io: _root._io
         type: block
         pos: (_root.buddy_allocator_body.block_addresses[block_id] >> 0x05 << 0x05) + 4
@@ -120,7 +120,7 @@ types:
         repeat: expr
         repeat-expr: count
     instances:
-      block:
+      rightmost_block:
         io: _root._io
         type: block
         if: mode > 0

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -46,7 +46,7 @@ types:
       - id: block_addresses
         type: block_descriptor
         repeat: expr
-        repeat-expr: 256
+        repeat-expr: num_block_addresses
         doc: Addresses of the different blocks
       - id: num_directories
         type: u4
@@ -59,8 +59,12 @@ types:
       - id: free_lists
         type: free_list
         repeat: expr
-        repeat-expr: 32
+        repeat-expr: num_free_lists
     instances:
+      num_block_addresses:
+        value: 256
+      num_free_lists:
+        value: 32
       directories:
         io: _root._io
         type: master_block_ref(_index)

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -21,6 +21,11 @@ instances:
     pos: buddy_allocator_header.ofs_bookkeeping_info_block + 4
     size: buddy_allocator_header.len_bookkeeping_info_block
     type: buddy_allocator_body
+  block_address_mask:
+    value: 0x1f
+    doc: |
+      Bitmask used to calculate the position and the size of each block
+      of the B-tree from the block addresses.
 types:
   buddy_allocator_header:
     seq:
@@ -68,12 +73,10 @@ types:
           - id: address_raw
             type: u4
         instances:
-          mask:
-            value: 0x1f
           offset:
-            value: (address_raw & ~mask) + 4
+            value: (address_raw & ~_root.block_address_mask) + 4
           size:
-            value: 1 << address_raw & mask
+            value: 1 << address_raw & _root.block_address_mask
       directory_entry:
         seq:
           - id: len_name

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -60,6 +60,15 @@ types:
         type: free_list
         repeat: expr
         repeat-expr: num_free_lists
+    types:
+      free_list:
+        seq:
+          - id: counter
+            type: u4
+          - id: offsets
+            type: u4
+            repeat: expr
+            repeat-expr: counter
     instances:
       num_block_addresses:
         value: 256
@@ -91,14 +100,6 @@ types:
         type: str
       - id: block_id
         type: u4
-  free_list:
-    seq:
-      - id: counter
-        type: u4
-      - id: offsets
-        type: u4
-        repeat: expr
-        repeat-expr: counter
   master_block_ref:
     params:
       - id: idx

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -11,7 +11,7 @@ doc-ref: |
   https://metacpan.org/pod/distribution/Mac-Finder-DSStore/DSStoreFormat.pod
   https://0day.work/parsing-the-ds_store-file-format
 seq:
-  - id: alignment
+  - id: alignment_header
     contents: [0x00, 0x00, 0x00, 0x01]
   - id: buddy_allocator_header
     type: buddy_allocator_header

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -3,6 +3,7 @@ meta:
   title: macOS '.DS_Store' format
   license: CC-BY-SA-4.0
   ks-version: 0.8
+  encoding: UTF-8
   endian: be
 doc: |
   Apple macOS '.DS_Store' file format.
@@ -73,7 +74,6 @@ types:
       - id: name
         size: len_name
         type: str
-        encoding: UTF-8
       - id: block_id
         type: u4
   free_list:
@@ -143,7 +143,6 @@ types:
       - id: data_type
         size: 4
         type: str
-        encoding: UTF-8
         doc: Data type of the value
       - id: value
         type:
@@ -192,4 +191,3 @@ types:
       - id: value
         size: 4
         type: str
-        encoding: UTF-8

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -18,8 +18,8 @@ seq:
 instances:
   buddy_allocator_body:
     type: buddy_allocator_body
-    pos: buddy_allocator_header.offset_bookkeeping_info_block + 4
     size: buddy_allocator_header.size_bookkeeping_info_block
+    pos: buddy_allocator_header.offset_bookkeeping_info_block + 4
 types:
   buddy_allocator_header:
     seq:
@@ -62,20 +62,20 @@ types:
     instances:
       directories:
         io: _root._io
+        size: 1 << block_addresses[directory_entries[0].block_id] & 0x1f
+        pos: (block_addresses[directory_entries[0].block_id] >> 0x05 << 0x05) + 4
         type: master_block
         repeat: expr
         repeat-expr: directory_count
-        pos: (block_addresses[directory_entries[0].block_id] >> 0x05 << 0x05) + 4
-        size: 1 << block_addresses[directory_entries[0].block_id] & 0x1f
         doc: Master blocks of the different B-trees
   directory_entry:
     seq:
       - id: name_len
         type: u1
       - id: name
+        size: name_len
         type: str
         encoding: UTF-8
-        size: name_len
       - id: block_id
         type: u4
   free_list:
@@ -105,8 +105,8 @@ types:
     instances:
       root_block:
         io: _root._io
-        type: block
         pos: (_root.buddy_allocator_body.block_addresses[block_id] >> 0x05 << 0x05) + 4
+        type: block
   block:
     seq:
       - id: mode
@@ -122,9 +122,9 @@ types:
     instances:
       rightmost_block:
         io: _root._io
+        pos: (_root.buddy_allocator_body.block_addresses[mode] >> 0x05 << 0x05) + 4
         type: block
         if: mode > 0
-        pos: (_root.buddy_allocator_body.block_addresses[mode] >> 0x05 << 0x05) + 4
         doc: Rightmost child block pointer
   record:
     seq:
@@ -134,9 +134,9 @@ types:
         type: four_char_code
         doc: Description of the entry's property
       - id: data_type
+        size: 4
         type: str
         encoding: UTF-8
-        size: 4
         doc: Data type of the value
       - id: value
         type:
@@ -163,9 +163,9 @@ types:
     instances:
       block:
         io: _root._io
+        pos: (_root.buddy_allocator_body.block_addresses[block_id] >> 0x05 << 0x05) + 4
         type: block
         if: mode > 0
-        pos: (_root.buddy_allocator_body.block_addresses[block_id] >> 0x05 << 0x05) + 4
   record_blob:
     seq:
       - id: length
@@ -177,12 +177,12 @@ types:
       - id: length
         type: u4
       - id: value
+        size: 2 * length
         type: str
         encoding: UTF-16BE
-        size: 2 * length
   four_char_code:
     seq:
       - id: value
+        size: 4
         type: str
         encoding: UTF-8
-        size: 4

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -90,7 +90,7 @@ types:
         type: u8
     instances:
       master_block:
-        pos: (_parent.block_addresses[_parent.directory_entries[idx].block_id] >> 0x05 << 0x05) + 4
+        pos: (_parent.block_addresses[_parent.directory_entries[idx].block_id] & ~0x1f) + 4
         size: 1 << _parent.block_addresses[_parent.directory_entries[idx].block_id] & 0x1f
         type: master_block
   master_block:
@@ -112,7 +112,7 @@ types:
     instances:
       root_block:
         io: _root._io
-        pos: (_root.buddy_allocator_body.block_addresses[block_id] >> 0x05 << 0x05) + 4
+        pos: (_root.buddy_allocator_body.block_addresses[block_id] & ~0x1f) + 4
         type: block
   block:
     seq:
@@ -129,7 +129,7 @@ types:
     instances:
       rightmost_block:
         io: _root._io
-        pos: (_root.buddy_allocator_body.block_addresses[mode] >> 0x05 << 0x05) + 4
+        pos: (_root.buddy_allocator_body.block_addresses[mode] & ~0x1f) + 4
         type: block
         if: mode > 0
         doc: Rightmost child block pointer
@@ -169,7 +169,7 @@ types:
     instances:
       block:
         io: _root._io
-        pos: (_root.buddy_allocator_body.block_addresses[block_id] >> 0x05 << 0x05) + 4
+        pos: (_root.buddy_allocator_body.block_addresses[block_id] & ~0x1f) + 4
         type: block
         if: mode > 0
   record_blob:

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -24,7 +24,7 @@ types:
   buddy_allocator_header:
     seq:
       - id: magic
-        contents: [0x42, 0x75, 0x64, 0x31]
+        contents: ["Bud1"]
         doc: Magic number 'Bud1'
       - id: ofs_bookkeeping_info_block
         type: u4

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -25,30 +25,36 @@ types:
     seq:
       - id: magic
         contents: [0x42, 0x75, 0x64, 0x31]
+        doc: Magic number 'Bud1'
       - id: offset_bookkeeping_info_block
         type: u4
       - id: size_bookkeeping_info_block
         type: u4
       - id: copy_offset_bookkeeping_info_block
         type: u4
+        doc: Needs to match 'offset_bookkeeping_info_block'
       - id: unused_block
         size: 16
   buddy_allocator_body:
     seq:
       - id: block_count
         type: u4
+        doc: Number of blocks in the allocated-blocks list
       - id: unknown_field
         size: 4
       - id: block_addresses
         type: u4
         repeat: expr
         repeat-expr: 256
+        doc: Addresses of the different blocks
       - id: directory_count
         type: u4
+        doc: Indicates the number of directory entries
       - id: directory_entries
         type: directory_entry
         repeat: expr
         repeat-expr: directory_count
+        doc: Each directory is an independent B-tree
       - id: free_lists
         type: free_list
         repeat: expr
@@ -61,6 +67,7 @@ types:
         repeat-expr: directory_count
         pos: (block_addresses[directory_entries[0].block_id] >> 0x05 << 0x05) + 4
         size: 1 << block_addresses[directory_entries[0].block_id] & 0x1f
+        doc: Master blocks of the different B-trees
   directory_entry:
     seq:
       - id: name_len
@@ -83,12 +90,16 @@ types:
     seq:
       - id: block_id
         type: u4
+        doc: Block number of the B-tree's root node
       - id: num_internal_nodes
         type: u4
+        doc: Number of internal node levels
       - id: num_records
         type: u4
+        doc: Number of records in the tree
       - id: num_nodes
         type: u4
+        doc: Number of nodes in the tree
       - id: unknown
         type: u4
     instances:
@@ -100,8 +111,10 @@ types:
     seq:
       - id: mode
         type: u4
+        doc: If mode is 0, this is a leaf node, otherwise it is an internal node
       - id: count
         type: u4
+        doc: Number of records or number of block id + record pairs
       - id: data
         type: block_data(mode)
         repeat: expr
@@ -112,16 +125,19 @@ types:
         type: block
         if: mode > 0
         pos: (_root.buddy_allocator_body.block_addresses[mode] >> 0x05 << 0x05) + 4
+        doc: Rightmost child block pointer
   record:
     seq:
       - id: filename
         type: ustr
       - id: structure_type
         type: four_char_code
+        doc: Description of the entry's property
       - id: data_type
         type: str
         encoding: UTF-8
         size: 4
+        doc: Data type of the value
       - id: value
         type:
           switch-on: data_type

--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -1,7 +1,7 @@
 meta:
   id: ds_store
   title: macOS '.DS_Store' format
-  license: CC-BY-SA-4.0
+  license: MIT
   ks-version: 0.8
   encoding: UTF-8
   endian: be


### PR DESCRIPTION
Hello,

This PR aims to add a description for the macOS `.DS_Store` files generated by the Finder. You can test the description on these files: [ds_store_samples.zip](https://github.com/kaitai-io/kaitai_struct_formats/files/3015783/ds_store_samples.zip)

There are two things I would like to improve though:

* The position of certain instances need to be calculated according to `alignment_header` but I didn't succeed to make it work. I had to manually add 4 to the result as in this example: `buddy_allocator_header.ofs_bookkeeping_info_block + 4`
* When I try to use `_index` lines 65 and 66, I get the following error: `undefined TypeError: this.directoryEntries[i] is undefined`. I think it is the same issue as described in https://github.com/kaitai-io/kaitai_struct/issues/436.

Could you please give me a hand on these two issues?

Thank you in advance.