### PR TITLE
Support TAP files that don't have 0x8000 in bytes block reserved field

### DIFF
--- a/filesystem/zx_spectrum_tap.ksy
+++ b/filesystem/zx_spectrum_tap.ksy
@@ -79,4 +79,4 @@ types:
       - id: start_address
         type: u2
       - id: reserved
-        contents: [0x00, 0x80]
+        size: 2


### PR DESCRIPTION
Contrary to what the file format spec describes the reserved field in a bytes block doesn't always contain 0x8000.