### PR TITLE
Fix version check in renderware_binary_stream.ksy

### DIFF
--- a/game/renderware_binary_stream.ksy
+++ b/game/renderware_binary_stream.ksy
@@ -10,7 +10,7 @@ seq:
     enum: sections
   - id: size
     type: u4
-  - id: version
+  - id: library_id_stamp
     type: u4
   - id: body
     size: size
@@ -23,6 +23,9 @@ seq:
         sections::geometry_list: list_with_header
         sections::texture_dictionary: list_with_header
         sections::texture_native: list_with_header
+instances:
+    version:
+      value: (library_id_stamp >> 16) + 0x30000
 types:
   list_with_header:
     doc: |
@@ -37,7 +40,7 @@ types:
         contents: [1, 0, 0, 0]
       - id: header_size
         type: u4
-      - id: version
+      - id: library_id_stamp
         type: u4
       - id: header
         size: header_size
@@ -52,6 +55,9 @@ types:
       - id: entries
         type: renderware_binary_stream
         repeat: eos
+    instances:
+        version:
+          value: (library_id_stamp >> 16) + 0x30000
   struct_texture_dictionary:
     seq:
       - id: num_textures

--- a/game/renderware_binary_stream.ksy
+++ b/game/renderware_binary_stream.ksy
@@ -25,7 +25,7 @@ seq:
         sections::texture_native: list_with_header
 instances:
   version:
-    value: (library_id_stamp >> 16) + 0x30000
+    value: library_id_stamp & 0xFFFF0000 != 0 ? (library_id_stamp >> 14 & 0x3FF00) + 0x30000 | (library_id_stamp >> 16 & 0x3F) : library_id_stamp << 8
 types:
   list_with_header:
     doc: |
@@ -57,7 +57,7 @@ types:
         repeat: eos
     instances:
       version:
-        value: (library_id_stamp >> 16) + 0x30000
+        value: library_id_stamp & 0xFFFF0000 != 0 ? (library_id_stamp >> 14 & 0x3FF00) + 0x30000 | (library_id_stamp >> 16 & 0x3F) : library_id_stamp << 8
   struct_texture_dictionary:
     seq:
       - id: num_textures

--- a/game/renderware_binary_stream.ksy
+++ b/game/renderware_binary_stream.ksy
@@ -24,8 +24,8 @@ seq:
         sections::texture_dictionary: list_with_header
         sections::texture_native: list_with_header
 instances:
-    version:
-      value: (library_id_stamp >> 16) + 0x30000
+  version:
+    value: (library_id_stamp >> 16) + 0x30000
 types:
   list_with_header:
     doc: |
@@ -56,8 +56,8 @@ types:
         type: renderware_binary_stream
         repeat: eos
     instances:
-        version:
-          value: (library_id_stamp >> 16) + 0x30000
+      version:
+        value: (library_id_stamp >> 16) + 0x30000
   struct_texture_dictionary:
     seq:
       - id: num_textures


### PR DESCRIPTION
The versions listed in the documentation do not match the library stamp id in the chunk headers. Change the chunk header field to a more approriate name and introduce a version instance variable to make the checks work.