### PR TITLE
Added smbios with some tables.

### DIFF
--- a/firmware/smbios/bios_information.ksy
+++ b/firmware/smbios/bios_information.ksy
@@ -1,0 +1,42 @@
+meta:
+  id: bios_information
+  endian: le
+  imports:
+    - strings
+seq:
+  - id: length
+    type: u1
+  - id: handle_index
+    type: u2
+  - id: vendor_index
+    type: u1
+  - id: bios_version
+    type: u1
+  - id: bios_starting_address_segment
+    type: u2
+  - id: bios_release_date_index
+    type: u1
+  - id: bios_rom_size
+    type: u1
+  - id: bios_characteristics
+    type: u8
+  - id: bios_characteristics_ext_bytes
+    size: length - 0x12
+  - id: strings_array
+    type: strings
+    # Repeat until [00, 00] is matched, this mean, double terminator byte (0)
+    # the trick here is _.string.length is the last string we have parsed and
+    # strings_array has to contain at least 2 elements.
+    repeat: until
+    repeat-until: _.string.length == 1 and strings_array.size > 1
+instances:
+  handle:
+    value: strings_array[handle_index - 1]
+    if: handle_index > 0
+  vendor:
+    value: strings_array[vendor_index - 1]
+    if: vendor_index > 0
+  bios_release_date:
+    value: strings_array[bios_release_date_index - 1]
+    if: bios_release_date_index > 0
+

--- a/firmware/smbios/portable_battery.ksy
+++ b/firmware/smbios/portable_battery.ksy
@@ -1,0 +1,71 @@
+meta:
+  id: portable_battery
+  endian: le
+  imports:
+    - strings
+seq:
+  - id: length
+    type: u1
+  - id: handle
+    type: u2
+  - id: location_index
+    type: u1
+  - id: manufacturer_index
+    type: u1
+  - id: manufacture_date_index
+    type: u1
+  - id: serial_number_index
+    type: u1
+  - id: device_name_index
+    type: u1
+  - id: device_chemistry
+    type: u1
+  - id: design_capacity
+    type: u2
+  - id: design_voltaje
+    type: u2
+  - id: sbds_version_number_index
+    type: u1
+  - id: maximum_error_in_battery_data
+    type: u1
+  - id: sbds_serial_number
+    type: u2
+  - id: dbds_manufacture_date
+    type: u2
+  - id: sbds_device_chemistry_index
+    type: u1
+  - id: design_capacity_multiplier
+    type: u1
+  - id: oem_specific
+    type: u4
+  - id: strings_array
+    type: strings
+    # Repeat until [00, 00] is matched, this mean, double terminator byte (0)
+    # the trick here is _.string.length is the last string we have parsed and
+    # strings_array has to contain at least 2 elements.
+    repeat: until
+    repeat-until: _.string.length == 1 and strings_array.size > 1
+instances:
+  location:
+    value: strings_array[location_index - 1]
+    if: location_index > 0
+  manufacturer:
+    value: strings_array[manufacturer_index - 1]
+    if: manufacturer_index > 0
+  manufacture_date:
+    value: strings_array[manufacture_date_index - 1]
+    if: manufacture_date_index > 0
+  serial_number:
+    value: strings_array[serial_number_index - 1]
+    if: serial_number_index > 0
+  device_name:
+    value: strings_array[device_name_index - 1]
+    if: device_name_index > 0
+  sbds_version_number:
+    value: strings_array[sbds_version_number_index - 1]
+    if: sbds_version_number_index > 0
+  sbds_device_chemistry:
+    value: strings_array[sbds_device_chemistry_index - 1]
+    if: sbds_device_chemistry_index > 0
+
+

--- a/firmware/smbios/processor_information.ksy
+++ b/firmware/smbios/processor_information.ksy
@@ -1,0 +1,88 @@
+meta:
+  id: processor_information
+  endian: le
+  imports:
+    - strings
+seq:
+  - id: length
+    type: u1
+  - id: handle
+    type: u2
+  - id: socket_designation_index
+    type: u1
+  - id: processor_type
+    type: u1
+  - id: processor_family
+    type: u1
+  - id: processor_manufacturer_index
+    type: u1
+  - id: processor_id
+    type: u8
+  - id: processor_version_index
+    type: u1
+  - id: voltage
+    type: u1
+  - id: external_clock
+    type: u2
+  - id: max_speed
+    type: u2
+  - id: current_speed
+    type: u2
+  - id: status
+    type: u1
+  - id: processor_upgrade
+    type: u1
+  - id: l1_cache_handle
+    type: u2
+  - id: l2_cache_handle
+    type: u2
+  - id: l3_cache_handle
+    type: u2
+  - id: serial_number_index
+    type: u1
+  - id: asset_tag_index
+    type: u1
+  - id: part_number_index
+    type: u1
+  - id: core_count
+    type: u1
+  - id: core_enabled
+    type: u1
+  - id: thread_count
+    type: u1
+  - id: processor_characteristics
+    type: u2
+  - id: processor_family_2
+    type: u2
+  - id: core_count_2
+    type: u2
+  - id: core_enabled_2
+    type: u2
+  - id: thread_count_2
+    type: u2
+  - id: strings_array
+    type: strings
+    # Repeat until [00, 00] is matched, this mean, double terminator byte (0)
+    # the trick here is _.string.length is the last string we have parsed and
+    # strings_array has to contain at least 2 elements.
+    repeat: until
+    repeat-until: _.string.length == 1 and strings_array.size > 1
+instances:
+  socket_designation:
+    value: strings_array[socket_designation_index - 1]
+    if: socket_designation_index > 0
+  processor_manufacturer:
+    value: strings_array[processor_manufacturer_index - 1]
+    if: processor_manufacturer_index > 0
+  processor_version:
+    value: strings_array[processor_version_index - 1]
+    if: processor_version_index > 0
+  serial_number:
+    value: strings_array[serial_number_index - 1]
+    if: serial_number_index > 0
+  asset_tag:
+    value: strings_array[asset_tag_index - 1]
+    if: asset_tag_index > 0
+  part_number:
+    value: strings_array[part_number_index - 1]
+    if: part_number_index > 0

--- a/firmware/smbios/skipper.ksy
+++ b/firmware/smbios/skipper.ksy
@@ -1,0 +1,17 @@
+meta:
+  id: skipper
+  endian: le
+  imports:
+    - strings
+seq:
+  - id: length
+    type: u1
+  - id: rest
+    size: length - 2
+  - id: strings_array
+    type: strings
+    # Repeat until [00, 00] is matched, this mean, double terminator byte (0)
+    # the trick here is _.string.length is the last string we have parsed and
+    # strings_array has to contain at least 2 elements.
+    repeat: until
+    repeat-until: _.string.length == 1 and strings_array.size > 1

--- a/firmware/smbios/smbios.ksy
+++ b/firmware/smbios/smbios.ksy
@@ -1,0 +1,37 @@
+meta:
+  id: smbios
+  endian: le
+  imports:
+    - bios_information
+    - system_information
+    - processor_information
+    - portable_battery
+    - skipper
+    - strings
+seq:
+  - id: tables
+    type: table
+    repeat: eos
+types:
+  table:
+    seq:
+      - id: type
+        type: u1
+        enum: type_enum
+      - id: table
+        type:
+          switch-on: type
+          cases:
+            # TODO: Add rest of the tables
+            'type_enum::table0': bios_information
+            'type_enum::table1': system_information
+            'type_enum::table4': processor_information
+            'type_enum::table22': portable_battery
+            _: skipper
+    enums:
+      type_enum:
+        0x00: table0
+        0x01: table1
+        0x04: table4
+        0x16: table22
+

--- a/firmware/smbios/strings.ksy
+++ b/firmware/smbios/strings.ksy
@@ -1,0 +1,9 @@
+meta:
+  id: strings
+  endian: le
+seq:
+  - id: string
+    type: strz
+    encoding: UTF-8
+    include: true
+

--- a/firmware/smbios/system_information.ksy
+++ b/firmware/smbios/system_information.ksy
@@ -1,0 +1,51 @@
+meta:
+  id: system_information
+  endian: le
+  imports:
+    - strings
+seq:
+  - id: length
+    type: u1
+  - id: handle
+    type: u2
+  - id: manufacturer_index
+    type: u1
+  - id: product_name_index
+    type: u1
+  - id: version_index
+    type: u1
+  - id: serial_number_index
+    type: u1
+  - id: uuid
+    size: 16
+  - id: wake_up_type
+    type: u1
+  - id: sku_number_index
+    type: u1
+  - id: family_index
+    type: u1
+  - id: strings_array
+    type: strings
+    repeat: until
+    repeat-until: _.string.length == 1 and strings_array.size > 1
+instances:
+  manufacturer:
+    value: strings_array[manufacturer_index - 1]
+    if: manufacturer_index > 0
+  product_name:
+    value: strings_array[product_name_index - 1]
+    if: product_name_index > 0
+  version:
+    value: strings_array[version_index - 1]
+    if: version_index > 0
+  serial_number:
+    value: strings_array[serial_number_index - 1]
+    if: serial_number_index > 0
+  sku_number:
+    value: strings_array[sku_number_index - 1]
+    if: sku_number_index > 0
+  family:
+    value: strings_array[family_index - 1]
+    if: family_index > 0
+
+


### PR DESCRIPTION
Added [smbios format](https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.1.1.pdf).

The current .ksy contains few tables like:

- Bios information
- System information
- Processor information
- Portable Battery information

To add more tables, create a new file with the table specification.
Also, there is a special name '**skipper**', that is used to parse any table who is not specified. 