### PR TITLE
Add PHP serialized value and phar archive format

### DIFF
--- a/archive/phar_without_stub.ksy
+++ b/archive/phar_without_stub.ksy
@@ -66,7 +66,7 @@ enums:
       id: openssl
       -orig-id: PHAR_SIG_OPENSSL
       doc: |
-        Indicates an OpenSSL signature. Available since API version 1.1.1. This type is not documented in the phar extension's documentation of the phar format.
+        Indicates an OpenSSL signature. Available since API version 1.1.1, PHP_Archive 0.12.0 (even though it claims to only support API version 1.1.0) and phar extension 1.3.0. This type is not documented in the phar extension's documentation of the phar format.
         
         Note: In older versions of the phar extension, this value was used for an undocumented and unimplemented "PGP" signature type (`PHAR_SIG_PGP`).
 types:

--- a/archive/phar_without_stub.ksy
+++ b/archive/phar_without_stub.ksy
@@ -1,0 +1,217 @@
+meta:
+  id: phar_without_stub
+  title: PHP phar archive (without stub)
+  application: PHP
+  file-extension: phar
+  xref:
+    wikidata: Q1269709
+  license: CC0-1.0
+  ks-version: 0.9
+  imports:
+    - /serialization/php_serialized_value
+  endian: le
+doc: |
+  A phar (PHP archive) file. The phar format is a custom archive format from the PHP ecosystem that is used to package a complete PHP library or application into a single self-contained archive. All phar archives start with an executable PHP stub, which can be used to allow executing or including phar files as if they were regular PHP scripts. PHP 5.3 and later include the phar extension, which adds native support for reading and manipulating phar files.
+  
+  The phar format was originally developed as part of the PEAR library PHP_Archive, first released in 2005. Later, a native PHP extension named "phar" was developed, which was first released on PECL in 2007, and is included with PHP 5.3 and later. The phar extension has effectively superseded the PHP_Archive library, which has not been updated since 2010. The phar extension is also no longer released independently on PECL; it is now developed and released as part of PHP itself.
+  
+  Because of current limitations in Kaitai Struct (see kaitai-io/kaitai_struct#158 and kaitai-io/kaitai_struct#538), the executable PHP stub that precedes the rest of the archive is not handled by this spec. Before parsing a phar using this spec, the stub must be removed manually.
+  
+  A phar's stub is terminated by the special token `__HALT_COMPILER();` (which may be followed by at most one space, the PHP tag end `?>`, and an optional line terminator). The stub termination sequence is immediately followed by the remaining parts of the phar format, as described in this spec.
+  
+  The phar stub usually contains code that loads the phar and runs a contained PHP file, but this is not required. A minimal valid phar stub is `<?php __HALT_COMPILER();` - such a stub makes it impossible to execute the phar directly, but still allows loading or manipulating it using the phar extension.
+doc-ref:
+  - 'https://www.php.net/manual/en/phar.fileformat.php'
+  - 'https://github.com/php/php-src/tree/master/ext/phar'
+  - 'https://svn.php.net/viewvc/pecl/phar/'
+  - 'https://svn.php.net/viewvc/pear/packages/PHP_Archive/'
+seq:
+  - id: manifest
+    type: manifest
+    doc: The archive's manifest, containing general metadata about the archive and its files.
+  - id: files
+    size: manifest.file_entries[_index].compressed_size
+    repeat: expr
+    repeat-expr: manifest.file_count
+    doc: The contents of each file in the archive (possibly compressed, as indicated by the file's flags in the manifest). The files are stored in the same order as they appear in the manifest.
+  - id: signature
+    type: signature
+    size-eos: true
+    if: manifest.flags.has_signature
+    doc: |
+      The archive's signature - a digest of all archive data before the signature itself.
+      
+      Note: Almost all of the available "signature" types are actually hashes, not signatures, and cannot be used to verify that the archive has not been tampered with. Only the OpenSSL signature type is a true cryptographic signature.
+enums:
+  signature_type:
+    0x1:
+      id: md5
+      -orig-id: PHAR_SIG_MD5
+      doc: Indicates an MD5 hash.
+    0x2:
+      id: sha1
+      -orig-id: PHAR_SIG_SHA1
+      doc: Indicates a SHA-1 hash.
+    0x4:
+      id: sha256
+      -orig-id: PHAR_SIG_SHA256
+      doc: Indicates a SHA-256 hash. Available since API version 1.1.0, PHP_Archive 0.12.0 and phar extension 1.1.0.
+    0x8:
+      id: sha512
+      -orig-id: PHAR_SIG_SHA512
+      doc: Indicates a SHA-512 hash. Available since API version 1.1.0, PHP_Archive 0.12.0 and phar extension 1.1.0.
+    0x10:
+      id: openssl
+      -orig-id: PHAR_SIG_OPENSSL
+      doc: |
+        Indicates an OpenSSL signature. Available since API version 1.1.1. This type is not documented in the phar extension's documentation of the phar format.
+        
+        Note: In older versions of the phar extension, this value was used for an undocumented and unimplemented "PGP" signature type (`PHAR_SIG_PGP`).
+types:
+  serialized_value:
+    seq:
+      - id: raw
+        size-eos: true
+        doc: The serialized value, as a raw byte array.
+    instances:
+      parsed:
+        pos: 0
+        type: php_serialized_value
+        doc: The serialized value, parsed as a structure.
+  file_flags:
+    seq:
+      - id: value
+        type: u4
+        doc: The unparsed flag bits.
+    instances:
+      permissions:
+        value: value & 0x1ff
+        -orig-id: PHAR_ENT_PERM_MASK
+        doc: The file's permission bits.
+      zlib_compressed:
+        value: (value & 0x1000) != 0
+        -orig-id: PHAR_ENT_COMPRESSED_GZ
+        doc: Whether this file's data is stored using zlib compression.
+      bzip2_compressed:
+        value: (value & 0x2000) != 0
+        -orig-id: PHAR_ENT_COMPRESSED_BZ2
+        doc: Whether this file's data is stored using bzip2 compression.
+  file_entry:
+    seq:
+      - id: filename_size
+        type: u4
+        doc: The size of the file name, in bytes.
+      - id: filename
+        size: filename_size
+        doc: The name of this file. If the name ends with a slash, this entry represents a directory, otherwise a regular file. Directory entries are supported since phar API version 1.1.1. (Explicit directory entries are only needed for empty directories. Non-empty directories are implied by the files located inside them.)
+      - id: uncompressed_size
+        type: u4
+        doc: The size of the file's data when uncompressed, in bytes.
+      - id: timestamp
+        type: u4
+        doc: The time at which the file was added or last updated, as a Unix timestamp.
+      - id: compressed_size
+        type: u4
+        doc: The size of the file's data when compressed, in bytes.
+      - id: crc32
+        type: u4
+        doc: The CRC32 checksum of the file's uncompressed data.
+      - id: flags
+        type: file_flags
+        doc: Flags for this file.
+      - id: metadata_size
+        type: u4
+        doc: The size of the metadata, in bytes, or 0 if there is none.
+      - id: metadata
+        size: metadata_size
+        type: serialized_value
+        if: metadata_size != 0
+        doc: Metadata for this file, in the format used by PHP's `serialize` function. The meaning of the serialized data is not specified further, it may be used to store arbitrary custom data about the file.
+  api_version:
+    meta:
+      endian: be
+    seq:
+      - id: release
+        type: b4
+      - id: major
+        type: b4
+      - id: minor
+        type: b4
+      - id: unused
+        type: b4
+    doc: |
+      A phar API version number. This version number is meant to indicate which features are used in a specific phar, so that tools reading the phar can easily check that they support all necessary features.
+      
+      The following API versions exist so far:
+      
+      * 0.5, 0.6, 0.7, 0.7.1: The first official API versions. At this point, the phar format was only used by the PHP_Archive library, and the API version numbers were identical to the PHP_Archive versions that supported them. Development of the native phar extension started around API version 0.7. These API versions could only be queried using the `PHP_Archive::APIversion()` method, but were not stored physically in archives. These API versions are not supported by this spec.
+      * 0.8.0: Used by PHP_Archive 0.8.0 (released 2006-07-18) and later development versions of the phar extension. This is the first version number to be physically stored in archives. This API version is not supported by this spec.
+      * 0.9.0: Used by later development/early beta versions of the phar extension. Also temporarily used by PHP_Archive 0.9.0 (released 2006-12-15), but reverted back to API version 0.8.0 in PHP_Archive 0.9.1 (released 2007-01-05).
+      * 1.0.0: Supported since PHP_Archive 0.10.0 (released 2007-05-29) and phar extension 1.0.0 (released 2007-03-28). This is the first stable, forwards-compatible and documented version of the format.
+      * 1.1.0: Supported since PHP_Archive 0.12.0 (released 2015-07-06) and phar extension 1.1.0 (released 2007-04-12). Adds SHA-256 and SHA-512 signature types.
+      * 1.1.1: Supported since phar extension 2.0.0 (released 2009-07-29 and included with PHP 5.3 and later). (PHP_Archive 0.12.0 also supports all features from API verison 1.1.1, but it reports API version 1.1.0.) Adds the OpenSSL signature type and support for storing empty directories.
+  global_flags:
+    seq:
+      - id: value
+        type: u4
+        doc: The unparsed flag bits.
+    instances:
+      any_zlib_compressed:
+        value: (value & 0x1000) != 0
+        -orig-id: PHAR_HDR_COMPRESSED_GZ
+        doc: Whether any of the files in this phar are stored using zlib compression.
+      any_bzip2_compressed:
+        value: (value & 0x2000) != 0
+        -orig-id: PHAR_HDR_COMPRESSED_BZ2
+        doc: Whether any of the files in this phar are stored using bzip2 compression.
+      has_signature:
+        value: (value & 0x10000) != 0
+        -orig-id: PHAR_HDR_SIGNATURE
+        doc: Whether this phar contains a signature.
+  manifest:
+    seq:
+      - id: manifest_size
+        type: u4
+        doc: |
+          The size of the manifest, in bytes.
+          
+          Note: The phar extension does not allow reading manifests larger than 100 MiB.
+      - id: file_count
+        type: u4
+        doc: The number of files in this phar.
+      - id: api_version
+        type: api_version
+        doc: The API version used by this phar manifest.
+      - id: flags
+        type: global_flags
+        doc: Global flags for this phar.
+      - id: alias_size
+        type: u4
+        doc: The size of the alias, in bytes.
+      - id: alias
+        size: alias_size
+        doc: The phar's alias, i. e. the name under which it is loaded into PHP.
+      - id: metadata_size
+        type: u4
+        doc: The size of the metadata, in bytes, or 0 if there is none.
+      - id: metadata
+        size: metadata_size
+        type: serialized_value
+        if: metadata_size != 0
+        doc: Metadata for this phar, in the format used by PHP's `serialize` function. The meaning of the serialized data is not specified further, it may be used to store arbitrary custom data about the archive.
+      - id: file_entries
+        type: file_entry
+        repeat: expr
+        repeat-expr: file_count
+        doc: Manifest entries for the files contained in this phar.
+  signature:
+    seq:
+      - id: data
+        size: _io.size - _io.pos - 8
+        doc: The signature data. The size and contents depend on the signature type.
+      - id: type
+        type: u4
+        enum: signature_type
+        doc: The signature type.
+      - id: magic
+        contents: "GBMB"

--- a/archive/phar_without_stub.ksy
+++ b/archive/phar_without_stub.ksy
@@ -32,9 +32,9 @@ seq:
     type: manifest
     doc: The archive's manifest, containing general metadata about the archive and its files.
   - id: files
-    size: manifest.file_entries[_index].compressed_size
+    size: manifest.file_entries[_index].len_data_compressed
     repeat: expr
-    repeat-expr: manifest.file_count
+    repeat-expr: manifest.num_files
     doc: The contents of each file in the archive (possibly compressed, as indicated by the file's flags in the manifest). The files are stored in the same order as they appear in the manifest.
   - id: signature
     type: signature
@@ -100,34 +100,34 @@ types:
         doc: Whether this file's data is stored using bzip2 compression.
   file_entry:
     seq:
-      - id: filename_size
+      - id: len_filename
         type: u4
-        doc: The size of the file name, in bytes.
+        doc: The length of the file name, in bytes.
       - id: filename
-        size: filename_size
+        size: len_filename
         doc: The name of this file. If the name ends with a slash, this entry represents a directory, otherwise a regular file. Directory entries are supported since phar API version 1.1.1. (Explicit directory entries are only needed for empty directories. Non-empty directories are implied by the files located inside them.)
-      - id: uncompressed_size
+      - id: len_data_uncompressed
         type: u4
-        doc: The size of the file's data when uncompressed, in bytes.
+        doc: The length of the file's data when uncompressed, in bytes.
       - id: timestamp
         type: u4
         doc: The time at which the file was added or last updated, as a Unix timestamp.
-      - id: compressed_size
+      - id: len_data_compressed
         type: u4
-        doc: The size of the file's data when compressed, in bytes.
+        doc: The length of the file's data when compressed, in bytes.
       - id: crc32
         type: u4
         doc: The CRC32 checksum of the file's uncompressed data.
       - id: flags
         type: file_flags
         doc: Flags for this file.
-      - id: metadata_size
+      - id: len_metadata
         type: u4
-        doc: The size of the metadata, in bytes, or 0 if there is none.
+        doc: The length of the metadata, in bytes, or 0 if there is none.
       - id: metadata
-        size: metadata_size
+        size: len_metadata
         type: serialized_value
-        if: metadata_size != 0
+        if: len_metadata != 0
         doc: Metadata for this file, in the format used by PHP's `serialize` function. The meaning of the serialized data is not specified further, it may be used to store arbitrary custom data about the file.
   api_version:
     meta:
@@ -172,13 +172,13 @@ types:
         doc: Whether this phar contains a signature.
   manifest:
     seq:
-      - id: manifest_size
+      - id: len_manifest
         type: u4
         doc: |
-          The size of the manifest, in bytes.
+          The length of the manifest, in bytes.
           
           Note: The phar extension does not allow reading manifests larger than 100 MiB.
-      - id: file_count
+      - id: num_files
         type: u4
         doc: The number of files in this phar.
       - id: api_version
@@ -187,24 +187,24 @@ types:
       - id: flags
         type: global_flags
         doc: Global flags for this phar.
-      - id: alias_size
+      - id: len_alias
         type: u4
-        doc: The size of the alias, in bytes.
+        doc: The length of the alias, in bytes.
       - id: alias
-        size: alias_size
+        size: len_alias
         doc: The phar's alias, i. e. the name under which it is loaded into PHP.
-      - id: metadata_size
+      - id: len_metadata
         type: u4
         doc: The size of the metadata, in bytes, or 0 if there is none.
       - id: metadata
-        size: metadata_size
+        size: len_metadata
         type: serialized_value
-        if: metadata_size != 0
+        if: len_metadata != 0
         doc: Metadata for this phar, in the format used by PHP's `serialize` function. The meaning of the serialized data is not specified further, it may be used to store arbitrary custom data about the archive.
       - id: file_entries
         type: file_entry
         repeat: expr
-        repeat-expr: file_count
+        repeat-expr: num_files
         doc: Manifest entries for the files contained in this phar.
   signature:
     seq:

--- a/archive/phar_without_stub.ksy
+++ b/archive/phar_without_stub.ksy
@@ -11,17 +11,45 @@ meta:
     - /serialization/php_serialized_value
   endian: le
 doc: |
-  A phar (PHP archive) file. The phar format is a custom archive format from the PHP ecosystem that is used to package a complete PHP library or application into a single self-contained archive. All phar archives start with an executable PHP stub, which can be used to allow executing or including phar files as if they were regular PHP scripts. PHP 5.3 and later include the phar extension, which adds native support for reading and manipulating phar files.
+  A phar (PHP archive) file. The phar format is a custom archive format
+  from the PHP ecosystem that is used to package a complete PHP library
+  or application into a single self-contained archive.
+  All phar archives start with an executable PHP stub, which can be used to
+  allow executing or including phar files as if they were regular PHP scripts.
+  PHP 5.3 and later include the phar extension, which adds native support for
+  reading and manipulating phar files.
   
-  The phar format was originally developed as part of the PEAR library PHP_Archive, first released in 2005. Later, a native PHP extension named "phar" was developed, which was first released on PECL in 2007, and is included with PHP 5.3 and later. The phar extension has effectively superseded the PHP_Archive library, which has not been updated since 2010. The phar extension is also no longer released independently on PECL; it is now developed and released as part of PHP itself.
+  The phar format was originally developed as part of the PEAR library
+  PHP_Archive, first released in 2005. Later, a native PHP extension
+  named "phar" was developed, which was first released on PECL in 2007,
+  and is included with PHP 5.3 and later. The phar extension has effectively
+  superseded the PHP_Archive library, which has not been updated since 2010.
+  The phar extension is also no longer released independently on PECL;
+  it is now developed and released as part of PHP itself.
   
-  Because of current limitations in Kaitai Struct (see kaitai-io/kaitai_struct#158 and kaitai-io/kaitai_struct#538), the executable PHP stub that precedes the rest of the archive is not handled by this spec. Before parsing a phar using this spec, the stub must be removed manually.
+  Because of current limitations in Kaitai Struct
+  (seekaitai-io/kaitai_struct#158 and kaitai-io/kaitai_struct#538),
+  the executable PHP stub that precedes the rest of the archive is not handled
+  by this spec. Before parsing a phar using this spec, the stub must be
+  removed manually.
   
-  A phar's stub is terminated by the special token `__HALT_COMPILER();` (which may be followed by at most one space, the PHP tag end `?>`, and an optional line terminator). The stub termination sequence is immediately followed by the remaining parts of the phar format, as described in this spec.
+  A phar's stub is terminated by the special token `__HALT_COMPILER();`
+  (which may be followed by at most one space, the PHP tag end `?>`,
+  and an optional line terminator). The stub termination sequence is
+  immediately followed by the remaining parts of the phar format,
+  as described in this spec.
   
-  The phar stub usually contains code that loads the phar and runs a contained PHP file, but this is not required. A minimal valid phar stub is `<?php __HALT_COMPILER();` - such a stub makes it impossible to execute the phar directly, but still allows loading or manipulating it using the phar extension.
+  The phar stub usually contains code that loads the phar and runs
+  a contained PHP file, but this is not required. A minimal valid phar stub
+  is `<?php __HALT_COMPILER();` - such a stub makes it impossible to execute
+  the phar directly, but still allows loading or manipulating it using the
+  phar extension.
   
-  Note: The phar format does not specify any encoding for text fields (stub, alias name, and all file names), so these fields may contain arbitrary binary data. The actual text encoding used in a specific phar file usually depends on the application that created the phar, and on the standard encoding of the system on which the phar was created.
+  Note: The phar format does not specify any encoding for text fields
+  (stub, alias name, and all file names), so these fields may contain arbitrary
+  binary data. The actual text encoding used in a specific phar file usually
+  depends on the application that created the phar, and on the
+  standard encoding of the system on which the phar was created.
 doc-ref:
   - 'https://www.php.net/manual/en/phar.fileformat.php'
   - 'https://github.com/php/php-src/tree/master/ext/phar'
@@ -30,20 +58,29 @@ doc-ref:
 seq:
   - id: manifest
     type: manifest
-    doc: The archive's manifest, containing general metadata about the archive and its files.
+    doc: |
+      The archive's manifest, containing general metadata about the archive
+      and its files.
   - id: files
     size: manifest.file_entries[_index].len_data_compressed
     repeat: expr
     repeat-expr: manifest.num_files
-    doc: The contents of each file in the archive (possibly compressed, as indicated by the file's flags in the manifest). The files are stored in the same order as they appear in the manifest.
+    doc: |
+      The contents of each file in the archive (possibly compressed,
+      as indicated by the file's flags in the manifest). The files are stored
+      in the same order as they appear in the manifest.
   - id: signature
     type: signature
     size-eos: true
     if: manifest.flags.has_signature
     doc: |
-      The archive's signature - a digest of all archive data before the signature itself.
+      The archive's signature - a digest of all archive data before
+      the signature itself.
       
-      Note: Almost all of the available "signature" types are actually hashes, not signatures, and cannot be used to verify that the archive has not been tampered with. Only the OpenSSL signature type is a true cryptographic signature.
+      Note: Almost all of the available "signature" types are actually hashes,
+      not signatures, and cannot be used to verify that the archive has not
+      been tampered with. Only the OpenSSL signature type is a true
+      cryptographic signature.
 enums:
   signature_type:
     0x1:
@@ -57,18 +94,27 @@ enums:
     0x4:
       id: sha256
       -orig-id: PHAR_SIG_SHA256
-      doc: Indicates a SHA-256 hash. Available since API version 1.1.0, PHP_Archive 0.12.0 and phar extension 1.1.0.
+      doc: |
+        Indicates a SHA-256 hash. Available since API version 1.1.0,
+        PHP_Archive 0.12.0 and phar extension 1.1.0.
     0x8:
       id: sha512
       -orig-id: PHAR_SIG_SHA512
-      doc: Indicates a SHA-512 hash. Available since API version 1.1.0, PHP_Archive 0.12.0 and phar extension 1.1.0.
+      doc: |
+        Indicates a SHA-512 hash. Available since API version 1.1.0,
+        PHP_Archive 0.12.0 and phar extension 1.1.0.
     0x10:
       id: openssl
       -orig-id: PHAR_SIG_OPENSSL
       doc: |
-        Indicates an OpenSSL signature. Available since API version 1.1.1, PHP_Archive 0.12.0 (even though it claims to only support API version 1.1.0) and phar extension 1.3.0. This type is not documented in the phar extension's documentation of the phar format.
+        Indicates an OpenSSL signature. Available since API version 1.1.1,
+        PHP_Archive 0.12.0 (even though it claims to only support
+        API version 1.1.0) and phar extension 1.3.0. This type is not
+        documented in the phar extension's documentation of the phar format.
         
-        Note: In older versions of the phar extension, this value was used for an undocumented and unimplemented "PGP" signature type (`PHAR_SIG_PGP`).
+        Note: In older versions of the phar extension, this value was used
+        for an undocumented and unimplemented "PGP" signature type
+        (`PHAR_SIG_PGP`).
 types:
   serialized_value:
     seq:
@@ -105,13 +151,20 @@ types:
         doc: The length of the file name, in bytes.
       - id: filename
         size: len_filename
-        doc: The name of this file. If the name ends with a slash, this entry represents a directory, otherwise a regular file. Directory entries are supported since phar API version 1.1.1. (Explicit directory entries are only needed for empty directories. Non-empty directories are implied by the files located inside them.)
+        doc: |
+          The name of this file. If the name ends with a slash, this entry
+          represents a directory, otherwise a regular file. Directory entries
+          are supported since phar API version 1.1.1.
+          (Explicit directory entries are only needed for empty directories.
+          Non-empty directories are implied by the files located inside them.)
       - id: len_data_uncompressed
         type: u4
         doc: The length of the file's data when uncompressed, in bytes.
       - id: timestamp
         type: u4
-        doc: The time at which the file was added or last updated, as a Unix timestamp.
+        doc: |
+          The time at which the file was added or last updated, as a
+          Unix timestamp.
       - id: len_data_compressed
         type: u4
         doc: The length of the file's data when compressed, in bytes.
@@ -128,7 +181,11 @@ types:
         size: len_metadata
         type: serialized_value
         if: len_metadata != 0
-        doc: Metadata for this file, in the format used by PHP's `serialize` function. The meaning of the serialized data is not specified further, it may be used to store arbitrary custom data about the file.
+        doc: |
+          Metadata for this file, in the format used by PHP's
+          `serialize` function. The meaning of the serialized data is not
+          specified further, it may be used to store arbitrary custom data
+          about the file.
   api_version:
     meta:
       endian: be
@@ -142,16 +199,38 @@ types:
       - id: unused
         type: b4
     doc: |
-      A phar API version number. This version number is meant to indicate which features are used in a specific phar, so that tools reading the phar can easily check that they support all necessary features.
+      A phar API version number. This version number is meant to indicate
+      which features are used in a specific phar, so that tools reading
+      the phar can easily check that they support all necessary features.
       
       The following API versions exist so far:
       
-      * 0.5, 0.6, 0.7, 0.7.1: The first official API versions. At this point, the phar format was only used by the PHP_Archive library, and the API version numbers were identical to the PHP_Archive versions that supported them. Development of the native phar extension started around API version 0.7. These API versions could only be queried using the `PHP_Archive::APIversion()` method, but were not stored physically in archives. These API versions are not supported by this spec.
-      * 0.8.0: Used by PHP_Archive 0.8.0 (released 2006-07-18) and later development versions of the phar extension. This is the first version number to be physically stored in archives. This API version is not supported by this spec.
-      * 0.9.0: Used by later development/early beta versions of the phar extension. Also temporarily used by PHP_Archive 0.9.0 (released 2006-12-15), but reverted back to API version 0.8.0 in PHP_Archive 0.9.1 (released 2007-01-05).
-      * 1.0.0: Supported since PHP_Archive 0.10.0 (released 2007-05-29) and phar extension 1.0.0 (released 2007-03-28). This is the first stable, forwards-compatible and documented version of the format.
-      * 1.1.0: Supported since PHP_Archive 0.12.0 (released 2015-07-06) and phar extension 1.1.0 (released 2007-04-12). Adds SHA-256 and SHA-512 signature types.
-      * 1.1.1: Supported since phar extension 2.0.0 (released 2009-07-29 and included with PHP 5.3 and later). (PHP_Archive 0.12.0 also supports all features from API verison 1.1.1, but it reports API version 1.1.0.) Adds the OpenSSL signature type and support for storing empty directories.
+      * 0.5, 0.6, 0.7, 0.7.1: The first official API versions. At this point,
+        the phar format was only used by the PHP_Archive library, and the
+        API version numbers were identical to the PHP_Archive versions that
+        supported them. Development of the native phar extension started around
+        API version 0.7. These API versions could only be queried using the
+        `PHP_Archive::APIversion()` method, but were not stored physically
+        in archives. These API versions are not supported by this spec.
+      * 0.8.0: Used by PHP_Archive 0.8.0 (released 2006-07-18) and
+        later development versions of the phar extension. This is the first
+        version number to be physically stored in archives. This API version
+        is not supported by this spec.
+      * 0.9.0: Used by later development/early beta versions of the
+        phar extension. Also temporarily used by PHP_Archive 0.9.0
+        (released 2006-12-15), but reverted back to API version 0.8.0 in
+        PHP_Archive 0.9.1 (released 2007-01-05).
+      * 1.0.0: Supported since PHP_Archive 0.10.0 (released 2007-05-29)
+        and phar extension 1.0.0 (released 2007-03-28). This is the first
+        stable, forwards-compatible and documented version of the format.
+      * 1.1.0: Supported since PHP_Archive 0.12.0 (released 2015-07-06)
+        and phar extension 1.1.0 (released 2007-04-12). Adds SHA-256 and
+        SHA-512 signature types.
+      * 1.1.1: Supported since phar extension 2.0.0 (released 2009-07-29 and
+        included with PHP 5.3 and later). (PHP_Archive 0.12.0 also supports
+        all features from API verison 1.1.1, but it reports API version 1.1.0.)
+        Adds the OpenSSL signature type and support for storing
+        empty directories.
   global_flags:
     seq:
       - id: value
@@ -161,11 +240,15 @@ types:
       any_zlib_compressed:
         value: (value & 0x1000) != 0
         -orig-id: PHAR_HDR_COMPRESSED_GZ
-        doc: Whether any of the files in this phar are stored using zlib compression.
+        doc: |
+          Whether any of the files in this phar are stored using
+          zlib compression.
       any_bzip2_compressed:
         value: (value & 0x2000) != 0
         -orig-id: PHAR_HDR_COMPRESSED_BZ2
-        doc: Whether any of the files in this phar are stored using bzip2 compression.
+        doc: |
+          Whether any of the files in this phar are stored using
+          bzip2 compression.
       has_signature:
         value: (value & 0x10000) != 0
         -orig-id: PHAR_HDR_SIGNATURE
@@ -177,7 +260,8 @@ types:
         doc: |
           The length of the manifest, in bytes.
           
-          Note: The phar extension does not allow reading manifests larger than 100 MiB.
+          Note: The phar extension does not allow reading manifests
+          larger than 100 MiB.
       - id: num_files
         type: u4
         doc: The number of files in this phar.
@@ -192,7 +276,8 @@ types:
         doc: The length of the alias, in bytes.
       - id: alias
         size: len_alias
-        doc: The phar's alias, i. e. the name under which it is loaded into PHP.
+        doc: |
+          The phar's alias, i. e. the name under which it is loaded into PHP.
       - id: len_metadata
         type: u4
         doc: The size of the metadata, in bytes, or 0 if there is none.
@@ -200,7 +285,11 @@ types:
         size: len_metadata
         type: serialized_value
         if: len_metadata != 0
-        doc: Metadata for this phar, in the format used by PHP's `serialize` function. The meaning of the serialized data is not specified further, it may be used to store arbitrary custom data about the archive.
+        doc: |
+          Metadata for this phar, in the format used by PHP's
+          `serialize` function. The meaning of the serialized data is not
+          specified further, it may be used to store arbitrary custom data
+          about the archive.
       - id: file_entries
         type: file_entry
         repeat: expr
@@ -210,7 +299,9 @@ types:
     seq:
       - id: data
         size: _io.size - _io.pos - 8
-        doc: The signature data. The size and contents depend on the signature type.
+        doc: |
+          The signature data. The size and contents depend on the
+          signature type.
       - id: type
         type: u4
         enum: signature_type

--- a/archive/phar_without_stub.ksy
+++ b/archive/phar_without_stub.ksy
@@ -20,6 +20,8 @@ doc: |
   A phar's stub is terminated by the special token `__HALT_COMPILER();` (which may be followed by at most one space, the PHP tag end `?>`, and an optional line terminator). The stub termination sequence is immediately followed by the remaining parts of the phar format, as described in this spec.
   
   The phar stub usually contains code that loads the phar and runs a contained PHP file, but this is not required. A minimal valid phar stub is `<?php __HALT_COMPILER();` - such a stub makes it impossible to execute the phar directly, but still allows loading or manipulating it using the phar extension.
+  
+  Note: The phar format does not specify any encoding for text fields (stub, alias name, and all file names), so these fields may contain arbitrary binary data. The actual text encoding used in a specific phar file usually depends on the application that created the phar, and on the standard encoding of the system on which the phar was created.
 doc-ref:
   - 'https://www.php.net/manual/en/phar.fileformat.php'
   - 'https://github.com/php/php-src/tree/master/ext/phar'

--- a/serialization/php_serialized_value.ksy
+++ b/serialization/php_serialized_value.ksy
@@ -5,12 +5,26 @@ meta:
   license: CC0-1.0
   ks-version: 0.9
   # No endianness, since all numbers are stored as ASCII decimal.
-  # This encoding is only used to parse numbers. All strings, class names, etc. are treated as raw byte arrays, because PHP strings are byte strings with no particular encoding.
+  # This encoding is only used to parse numbers. All strings, class names, etc.
+  # are treated as raw byte arrays, because PHP strings are byte strings
+  # with no particular encoding.
   encoding: ASCII
 doc: |
-  A serialized PHP value, in the format used by PHP's built-in `serialize` and `unserialize` functions. This format closely mirrors PHP's data model: it supports all of PHP's scalar types (`NULL`, booleans, numbers, strings), associative arrays, objects, and recursive data structures using references. The only PHP values not supported by this format are *resources*, which usually correspond to native file or connection handles and cannot be meaningfully serialized.
+  A serialized PHP value, in the format used by PHP's built-in `serialize` and
+  `unserialize` functions. This format closely mirrors PHP's data model:
+  it supports all of PHP's scalar types (`NULL`, booleans, numbers, strings),
+  associative arrays, objects, and recursive data structures using references.
+  The only PHP values not supported by this format are *resources*,
+  which usually correspond to native file or connection handles and cannot be
+  meaningfully serialized.
   
-  There is no official documentation for this data format; this spec was created based on the PHP source code and the behavior of `serialize`/`unserialize`. PHP makes no guarantees about compatibility of serialized data between PHP versions, but in practice, the format has remained fully backwards-compatible - values serialized by an older PHP version can be unserialized on any newer PHP version. This spec supports serialized values from PHP 7.3 or any earlier version.
+  There is no official documentation for this data format;
+  this spec was created based on the PHP source code and the behavior of
+  `serialize`/`unserialize`. PHP makes no guarantees about compatibility of
+  serialized data between PHP versions, but in practice, the format has
+  remained fully backwards-compatible - values serialized by an older
+  PHP version can be unserialized on any newer PHP version.
+  This spec supports serialized values from PHP 7.3 or any earlier version.
 doc-ref:
   - 'https://www.php.net/manual/en/function.serialize.php'
   - 'https://www.php.net/manual/en/function.serialize.php#66147'
@@ -35,27 +49,39 @@ seq:
         'value_type::array': array_contents
         'value_type::php_3_object': php_3_object_contents
         'value_type::object': object_contents
-        'value_type::custom_serialized_object': custom_serialized_object_contents
+        'value_type::custom_serialized_object':
+          custom_serialized_object_contents
         'value_type::variable_reference': int_contents
         'value_type::object_reference': int_contents
-    doc: The contents of the serialized value, which vary depending on the type.
+    doc: |
+      The contents of the serialized value, which vary depending on the type.
 enums:
   value_type:
     0x43: # 'C'
       id: custom_serialized_object
-      doc: An `object` whose class implements a custom serialized format using `Serializable`. Available since PHP 5.1.
+      doc: |
+        An `object` whose class implements a custom serialized format using
+        `Serializable`. Available since PHP 5.1.
     0x4e: # 'N'
       id: 'null'
       doc: A `NULL` value.
     0x4f: # 'O'
       id: object
-      doc: An `object` value (including its class name) serialized in the default format. Available since PHP 4.
+      doc: |
+        An `object` value (including its class name) serialized in the
+        default format. Available since PHP 4.
     0x52: # 'R'
       id: variable_reference
-      doc: An additional reference to a value that has already appeared earlier. Available since PHP 4.0.4.
+      doc: |
+        An additional reference to a value that has already appeared earlier.
+        Available since PHP 4.0.4.
     0x53: # 'S'
       id: php_6_string
-      doc: A `string` value from PHP 6. PHP 6 was never released, but support for deserializing PHP 6 strings was added in PHP 5.2.1 and is still present as of PHP 7.3. In all versions that support them (other than PHP 6), they are deserialized exactly like regular strings.
+      doc: |
+        A `string` value from PHP 6. PHP 6 was never released, but support for
+        deserializing PHP 6 strings was added in PHP 5.2.1 and is still present
+        as of PHP 7.3. In all versions that support them (other than PHP 6),
+        they are deserialized exactly like regular strings.
     0x61: # 'a'
       id: array
       doc: An `array` value.
@@ -73,10 +99,17 @@ enums:
       doc: |
         An `object` value (without a class name), as serialized by PHP 3.
         
-        PHP 4 through 7.3 included code to deserialize PHP 3 objects, which has now been removed from the development repo and will likely no longer be included in PHP 7.4. However, apparently this code has been broken ever since it was added - it cannot even deserialize a simple PHP 3 object like `o:0:{}`. If the code worked, PHP 3 objects deserialized under PHP 4 and higher would have the class `stdClass`.
+        PHP 4 through 7.3 included code to deserialize PHP 3 objects,
+        which has now been removed from the development repo and will likely
+        no longer be included in PHP 7.4. However, apparently this code
+        has been broken ever since it was added - it cannot even deserialize
+        a simple PHP 3 object like `o:0:{}`. If the code worked, PHP 3 objects
+        deserialized under PHP 4 and higher would have the class `stdClass`.
     0x72: # 'r'
       id: object_reference
-      doc: An `object` value which shares its identity with another `object` that has already appeared earlier. Available since PHP 5.
+      doc: |
+        An `object` value which shares its identity with another `object`
+        that has already appeared earlier. Available since PHP 5.
     0x73: # 's'
       id: string
       doc: A `string` value.
@@ -88,7 +121,9 @@ types:
     seq:
       - id: semicolon
         contents: ';'
-    doc: The contents of a null value (`value_type::null`). This structure contains no actual data, since there is only a single `NULL` value.
+    doc: |
+      The contents of a null value (`value_type::null`). This structure
+      contains no actual data, since there is only a single `NULL` value.
   bool_contents:
     seq:
       - id: colon
@@ -118,7 +153,9 @@ types:
         value: value_dec.to_i
         doc: The value of the `int`, parsed as an integer.
     doc: |
-      The contents of an integer-like value: either an actual integer (`value_type::int`) or a reference (`value_type::variable_reference`, `value_type::object_reference`).
+      The contents of an integer-like value:
+      either an actual integer (`value_type::int`) or a reference
+      (`value_type::variable_reference`, `value_type::object_reference`).
   float_contents:
     seq:
       - id: colon
@@ -127,11 +164,13 @@ types:
         type: str
         terminator: 0x3b # ';'
         doc: |
-          The value of the `float`, in ASCII decimal, as generated by PHP's usual double-to-string conversion. In particular, this means that:
+          The value of the `float`, in ASCII decimal, as generated by PHP's
+          usual double-to-string conversion. In particular, this means that:
           
           * A decimal point may not be included (for integral numbers)
           * The number may use exponent notation (e. g. `1.0E+16`)
-          * Positive and negative infinity are represented as `INF` and `-INF`, respectively
+          * Positive and negative infinity are represented as `INF`
+            and `-INF`, respectively
           * Not-a-number is represented as `NAN`
     doc: The contents of a floating-point value.
   length_prefixed_quoted_string:
@@ -139,7 +178,9 @@ types:
       - id: len_data_dec
         type: str
         terminator: 0x3a # ':'
-        doc: The length of the string's data in bytes, in ASCII decimal. The quotes are not counted in this length number.
+        doc: |
+          The length of the string's data in bytes, in ASCII decimal.
+          The quotes are not counted in this length number.
       - id: opening_quote
         contents: '"'
       - id: data
@@ -150,11 +191,16 @@ types:
     instances:
       len_data:
         value: len_data_dec.to_i
-        doc: The length of the string's contents in bytes, parsed as an integer. The quotes are not counted in this size number.
+        doc: |
+          The length of the string's contents in bytes, parsed as an integer.
+          The quotes are not counted in this size number.
     doc: |
       A quoted string prefixed with its length.
       
-      Despite the quotes surrounding the string data, it can contain arbitrary bytes, which are never escaped in any way. This does not cause any ambiguities when parsing - the bounds of the string are determined only by the length field, not by the quotes.
+      Despite the quotes surrounding the string data, it can contain
+      arbitrary bytes, which are never escaped in any way.
+      This does not cause any ambiguities when parsing - the bounds of
+      the string are determined only by the length field, not by the quotes.
   string_contents:
     seq:
       - id: colon
@@ -170,7 +216,8 @@ types:
     doc: |
       The contents of a string value.
       
-      Note: PHP strings can contain arbitrary byte sequences. They are not necessarily valid text in any specific encoding.
+      Note: PHP strings can contain arbitrary byte sequences.
+      They are not necessarily valid text in any specific encoding.
   mapping_entry:
     seq:
       - id: key
@@ -198,7 +245,8 @@ types:
     instances:
       num_entries:
         value: num_entries_dec.to_i
-        doc: The number of key-value pairs in the mapping, parsed as an integer.
+        doc: |
+          The number of key-value pairs in the mapping, parsed as an integer.
     doc: A mapping (a sequence of key-value pairs) prefixed with its size.
   array_contents:
     seq:
@@ -206,7 +254,9 @@ types:
         contents: ':'
       - id: elements
         type: count_prefixed_mapping
-        doc: The array's elements. Keys must be of type `int` or `string`, values may have any type.
+        doc: |
+          The array's elements. Keys must be of type `int` or `string`,
+          values may have any type.
     doc: The contents of an array value.
   php_3_object_contents:
     seq:
@@ -214,8 +264,12 @@ types:
         contents: ':'
       - id: properties
         type: count_prefixed_mapping
-        doc: The object's properties. Keys must be of type `string`, values may have any type.
-    doc: The contents of a PHP 3 object value. Unlike its counterpart in PHP 4 and above, it does not contain a class name.
+        doc: |
+          The object's properties. Keys must be of type `string`,
+          values may have any type.
+    doc: |
+      The contents of a PHP 3 object value. Unlike its counterpart in PHP 4
+      and above, it does not contain a class name.
   object_contents:
     seq:
       - id: colon1
@@ -227,8 +281,12 @@ types:
         contents: ':'
       - id: properties
         type: count_prefixed_mapping
-        doc: The object's properties. Keys ust be of type `string`, values may have any type.
-    doc: The contents of an object value serialized in the default format. Unlike its PHP 3 counterpart, it contains a class name.
+        doc: |
+          The object's properties. Keys ust be of type `string`,
+          values may have any type.
+    doc: |
+      The contents of an object value serialized in the default format.
+      Unlike its PHP 3 counterpart, it contains a class name.
   custom_serialized_object_contents:
     seq:
       - id: colon1
@@ -241,7 +299,9 @@ types:
       - id: len_data_dec
         type: str
         terminator: 0x3a # ':'
-        doc: The length of the serialized data in bytes, in ASCII decimal. The braces are not counted in this size number.
+        doc: |
+          The length of the serialized data in bytes, in ASCII decimal.
+          The braces are not counted in this size number.
       - id: opening_brace
         contents: '{'
       - id: data
@@ -249,11 +309,18 @@ types:
         doc: |
           The custom serialized data. The braces are not included.
           
-          Although the surrounding braces make it look like a regular serialized object, this field is actually more similar to a string: it can contain arbitrary data that is not required to follow any common structure.
+          Although the surrounding braces make it look like a regular
+          serialized object, this field is actually more similar to a string:
+          it can contain arbitrary data that is not required to follow
+          any common structure.
       - id: closing_quote
         contents: '}'
     instances:
       len_data:
         value: len_data_dec.to_i
-        doc: The length of the serialized data in bytes, parsed as an integer. The braces are not counted in this length number.
-    doc: The contents of an object value that implements a custom serialized format using `Serializable`.
+        doc: |
+          The length of the serialized data in bytes, parsed as an integer.
+          The braces are not counted in this length number.
+    doc: |
+      The contents of an object value that implements a custom
+      serialized format using `Serializable`.

--- a/serialization/php_serialized_value.ksy
+++ b/serialization/php_serialized_value.ksy
@@ -134,33 +134,33 @@ types:
           * Positive and negative infinity are represented as `INF` and `-INF`, respectively
           * Not-a-number is represented as `NAN`
     doc: The contents of a floating-point value.
-  size_prefixed_quoted_string:
+  length_prefixed_quoted_string:
     seq:
-      - id: size_dec
+      - id: len_data_dec
         type: str
         terminator: 0x3a # ':'
-        doc: The size of the string's data in bytes, in ASCII decimal. The quotes are not counted in this size number.
+        doc: The length of the string's data in bytes, in ASCII decimal. The quotes are not counted in this length number.
       - id: opening_quote
         contents: '"'
       - id: data
-        size: size
+        size: len_data
         doc: The data contained in the string. The quotes are not included.
       - id: closing_quote
         contents: '"'
     instances:
-      size:
-        value: size_dec.to_i
-        doc: The size of the string's contents in bytes, parsed as an integer. The quotes are not counted in this size number.
+      len_data:
+        value: len_data_dec.to_i
+        doc: The length of the string's contents in bytes, parsed as an integer. The quotes are not counted in this size number.
     doc: |
-      A quoted string prefixed with its size.
+      A quoted string prefixed with its length.
       
-      Despite the quotes surrounding the string data, it can contain arbitrary bytes, which are never escaped in any way. This does not cause any ambiguities when parsing - the bounds of the string are determined only by the size field, not by the quotes.
+      Despite the quotes surrounding the string data, it can contain arbitrary bytes, which are never escaped in any way. This does not cause any ambiguities when parsing - the bounds of the string are determined only by the length field, not by the quotes.
   string_contents:
     seq:
       - id: colon
         contents: ':'
       - id: string
-        type: size_prefixed_quoted_string
+        type: length_prefixed_quoted_string
       - id: semicolon
         contents: ';'
     instances:
@@ -180,9 +180,9 @@ types:
         type: php_serialized_value
         doc: The value of the entry.
     doc: A mapping entry consisting of a key and a value.
-  size_prefixed_mapping:
+  count_prefixed_mapping:
     seq:
-      - id: size_dec
+      - id: num_entries_dec
         type: str
         terminator: 0x3a # ':'
         doc: The number of key-value pairs in the mapping, in ASCII decimal.
@@ -191,13 +191,13 @@ types:
       - id: entries
         type: mapping_entry
         repeat: expr
-        repeat-expr: size
+        repeat-expr: num_entries
         doc: The key-value pairs contained in the mapping.
       - id: closing_brace
         contents: '}'
     instances:
-      size:
-        value: size_dec.to_i
+      num_entries:
+        value: num_entries_dec.to_i
         doc: The number of key-value pairs in the mapping, parsed as an integer.
     doc: A mapping (a sequence of key-value pairs) prefixed with its size.
   array_contents:
@@ -205,7 +205,7 @@ types:
       - id: colon
         contents: ':'
       - id: elements
-        type: size_prefixed_mapping
+        type: count_prefixed_mapping
         doc: The array's elements. Keys must be of type `int` or `string`, values may have any type.
     doc: The contents of an array value.
   php_3_object_contents:
@@ -213,7 +213,7 @@ types:
       - id: colon
         contents: ':'
       - id: properties
-        type: size_prefixed_mapping
+        type: count_prefixed_mapping
         doc: The object's properties. Keys must be of type `string`, values may have any type.
     doc: The contents of a PHP 3 object value. Unlike its counterpart in PHP 4 and above, it does not contain a class name.
   object_contents:
@@ -221,12 +221,12 @@ types:
       - id: colon1
         contents: ':'
       - id: class_name
-        type: size_prefixed_quoted_string
+        type: length_prefixed_quoted_string
         doc: The name of the object's class.
       - id: colon2
         contents: ':'
       - id: properties
-        type: size_prefixed_mapping
+        type: count_prefixed_mapping
         doc: The object's properties. Keys ust be of type `string`, values may have any type.
     doc: The contents of an object value serialized in the default format. Unlike its PHP 3 counterpart, it contains a class name.
   custom_serialized_object_contents:
@@ -234,18 +234,18 @@ types:
       - id: colon1
         contents: ':'
       - id: class_name
-        type: size_prefixed_quoted_string
+        type: length_prefixed_quoted_string
         doc: The name of the object's class.
       - id: colon2
         contents: ':'
-      - id: size_dec
+      - id: len_data_dec
         type: str
         terminator: 0x3a # ':'
-        doc: The size of the serialized data in bytes, in ASCII decimal. The braces are not counted in this size number.
+        doc: The length of the serialized data in bytes, in ASCII decimal. The braces are not counted in this size number.
       - id: opening_brace
         contents: '{'
       - id: data
-        size: size
+        size: len_data
         doc: |
           The custom serialized data. The braces are not included.
           
@@ -253,7 +253,7 @@ types:
       - id: closing_quote
         contents: '}'
     instances:
-      size:
-        value: size_dec.to_i
-        doc: The size of the serialized data in bytes, parsed as an integer. The braces are not counted in this size number.
+      len_data:
+        value: len_data_dec.to_i
+        doc: The length of the serialized data in bytes, parsed as an integer. The braces are not counted in this length number.
     doc: The contents of an object value that implements a custom serialized format using `Serializable`.

--- a/serialization/php_serialized_value.ksy
+++ b/serialization/php_serialized_value.ksy
@@ -2,7 +2,6 @@ meta:
   id: php_serialized_value
   title: Serialized PHP value
   application: PHP
-  file-extension: metadata.bin # Metadata stored as files in tar-based phar archives
   license: CC0-1.0
   ks-version: 0.9
   # No endianness, since all numbers are stored as ASCII decimal.

--- a/serialization/php_serialized_value.ksy
+++ b/serialization/php_serialized_value.ksy
@@ -1,0 +1,260 @@
+meta:
+  id: php_serialized_value
+  title: Serialized PHP value
+  application: PHP
+  file-extension: metadata.bin # Metadata stored as files in tar-based phar archives
+  license: CC0-1.0
+  ks-version: 0.9
+  # No endianness, since all numbers are stored as ASCII decimal.
+  # This encoding is only used to parse numbers. All strings, class names, etc. are treated as raw byte arrays, because PHP strings are byte strings with no particular encoding.
+  encoding: ASCII
+doc: |
+  A serialized PHP value, in the format used by PHP's built-in `serialize` and `unserialize` functions. This format closely mirrors PHP's data model: it supports all of PHP's scalar types (`NULL`, booleans, numbers, strings), associative arrays, objects, and recursive data structures using references. The only PHP values not supported by this format are *resources*, which usually correspond to native file or connection handles and cannot be meaningfully serialized.
+  
+  There is no official documentation for this data format; this spec was created based on the PHP source code and the behavior of `serialize`/`unserialize`. PHP makes no guarantees about compatibility of serialized data between PHP versions, but in practice, the format has remained fully backwards-compatible - values serialized by an older PHP version can be unserialized on any newer PHP version. This spec supports serialized values from PHP 7.3 or any earlier version.
+doc-ref:
+  - 'https://www.php.net/manual/en/function.serialize.php'
+  - 'https://www.php.net/manual/en/function.serialize.php#66147'
+  - 'https://www.php.net/manual/en/function.unserialize.php'
+  - 'https://github.com/php/php-src/blob/php-7.3.5/ext/standard/var_unserializer.re'
+  - 'https://github.com/php/php-src/blob/php-7.3.5/ext/standard/var.c#L822'
+seq:
+  - id: type
+    type: u1
+    enum: value_type
+    doc: A single-character code indicating the type of the serialized value.
+  - id: contents
+    type:
+      switch-on: type
+      cases:
+        'value_type::null': null_contents
+        'value_type::bool': bool_contents
+        'value_type::int': int_contents
+        'value_type::float': float_contents
+        'value_type::string': string_contents
+        'value_type::php_6_string': string_contents
+        'value_type::array': array_contents
+        'value_type::php_3_object': php_3_object_contents
+        'value_type::object': object_contents
+        'value_type::custom_serialized_object': custom_serialized_object_contents
+        'value_type::variable_reference': int_contents
+        'value_type::object_reference': int_contents
+    doc: The contents of the serialized value, which vary depending on the type.
+enums:
+  value_type:
+    0x43: # 'C'
+      id: custom_serialized_object
+      doc: An `object` whose class implements a custom serialized format using `Serializable`. Available since PHP 5.1.
+    0x4e: # 'N'
+      id: 'null'
+      doc: A `NULL` value.
+    0x4f: # 'O'
+      id: object
+      doc: An `object` value (including its class name) serialized in the default format. Available since PHP 4.
+    0x52: # 'R'
+      id: variable_reference
+      doc: An additional reference to a value that has already appeared earlier. Available since PHP 4.0.4.
+    0x53: # 'S'
+      id: php_6_string
+      doc: A `string` value from PHP 6. PHP 6 was never released, but support for deserializing PHP 6 strings was added in PHP 5.2.1 and is still present as of PHP 7.3. In all versions that support them (other than PHP 6), they are deserialized exactly like regular strings.
+    0x61: # 'a'
+      id: array
+      doc: An `array` value.
+    0x62: # 'b'
+      id: bool
+      doc: A `bool` value. Available since PHP 4.
+    0x64: # 'd'
+      id: float
+      doc: A `float` value.
+    0x69: # 'i'
+      id: int
+      doc: An `int` value.
+    0x6f: # 'o'
+      id: php_3_object
+      doc: |
+        An `object` value (without a class name), as serialized by PHP 3.
+        
+        PHP 4 through 7.3 included code to deserialize PHP 3 objects, which has now been removed from the development repo and will likely no longer be included in PHP 7.4. However, apparently this code has been broken ever since it was added - it cannot even deserialize a simple PHP 3 object like `o:0:{}`. If the code worked, PHP 3 objects deserialized under PHP 4 and higher would have the class `stdClass`.
+    0x72: # 'r'
+      id: object_reference
+      doc: An `object` value which shares its identity with another `object` that has already appeared earlier. Available since PHP 5.
+    0x73: # 's'
+      id: string
+      doc: A `string` value.
+  bool_value:
+    0x30: false # '0'
+    0x31: true # '1'
+types:
+  null_contents:
+    seq:
+      - id: semicolon
+        contents: ';'
+    doc: The contents of a null value (`value_type::null`). This structure contains no actual data, since there is only a single `NULL` value.
+  bool_contents:
+    seq:
+      - id: colon
+        contents: ':'
+      - id: value_dec
+        type: u1
+        enum: bool_value
+        doc: |
+          The value of the `bool`: `0` for `false` or `1` for `true`.
+      - id: semicolon
+        contents: ';'
+    instances:
+      value:
+        value: 'value_dec == bool_value::true'
+        doc: The value of the `bool`, parsed as a boolean.
+    doc: The contents of a boolean value (`value_type::bool`).
+  int_contents:
+    seq:
+      - id: colon
+        contents: ':'
+      - id: value_dec
+        type: str
+        terminator: 0x3b # ';'
+        doc: The value of the `int`, in ASCII decimal.
+    instances:
+      value:
+        value: value_dec.to_i
+        doc: The value of the `int`, parsed as an integer.
+    doc: |
+      The contents of an integer-like value: either an actual integer (`value_type::int`) or a reference (`value_type::variable_reference`, `value_type::object_reference`).
+  float_contents:
+    seq:
+      - id: colon
+        contents: ':'
+      - id: value_dec
+        type: str
+        terminator: 0x3b # ';'
+        doc: |
+          The value of the `float`, in ASCII decimal, as generated by PHP's usual double-to-string conversion. In particular, this means that:
+          
+          * A decimal point may not be included (for integral numbers)
+          * The number may use exponent notation (e. g. `1.0E+16`)
+          * Positive and negative infinity are represented as `INF` and `-INF`, respectively
+          * Not-a-number is represented as `NAN`
+    doc: The contents of a floating-point value.
+  size_prefixed_quoted_string:
+    seq:
+      - id: size_dec
+        type: str
+        terminator: 0x3a # ':'
+        doc: The size of the string's data in bytes, in ASCII decimal. The quotes are not counted in this size number.
+      - id: opening_quote
+        contents: '"'
+      - id: data
+        size: size
+        doc: The data contained in the string. The quotes are not included.
+      - id: closing_quote
+        contents: '"'
+    instances:
+      size:
+        value: size_dec.to_i
+        doc: The size of the string's contents in bytes, parsed as an integer. The quotes are not counted in this size number.
+    doc: |
+      A quoted string prefixed with its size.
+      
+      Despite the quotes surrounding the string data, it can contain arbitrary bytes, which are never escaped in any way. This does not cause any ambiguities when parsing - the bounds of the string are determined only by the size field, not by the quotes.
+  string_contents:
+    seq:
+      - id: colon
+        contents: ':'
+      - id: string
+        type: size_prefixed_quoted_string
+      - id: semicolon
+        contents: ';'
+    instances:
+      value:
+        value: string.data
+        doc: The value of the string, as a byte array.
+    doc: |
+      The contents of a string value.
+      
+      Note: PHP strings can contain arbitrary byte sequences. They are not necessarily valid text in any specific encoding.
+  mapping_entry:
+    seq:
+      - id: key
+        type: php_serialized_value
+        doc: The key of the entry.
+      - id: value
+        type: php_serialized_value
+        doc: The value of the entry.
+    doc: A mapping entry consisting of a key and a value.
+  size_prefixed_mapping:
+    seq:
+      - id: size_dec
+        type: str
+        terminator: 0x3a # ':'
+        doc: The number of key-value pairs in the mapping, in ASCII decimal.
+      - id: opening_brace
+        contents: '{'
+      - id: entries
+        type: mapping_entry
+        repeat: expr
+        repeat-expr: size
+        doc: The key-value pairs contained in the mapping.
+      - id: closing_brace
+        contents: '}'
+    instances:
+      size:
+        value: size_dec.to_i
+        doc: The number of key-value pairs in the mapping, parsed as an integer.
+    doc: A mapping (a sequence of key-value pairs) prefixed with its size.
+  array_contents:
+    seq:
+      - id: colon
+        contents: ':'
+      - id: elements
+        type: size_prefixed_mapping
+        doc: The array's elements. Keys must be of type `int` or `string`, values may have any type.
+    doc: The contents of an array value.
+  php_3_object_contents:
+    seq:
+      - id: colon
+        contents: ':'
+      - id: properties
+        type: size_prefixed_mapping
+        doc: The object's properties. Keys must be of type `string`, values may have any type.
+    doc: The contents of a PHP 3 object value. Unlike its counterpart in PHP 4 and above, it does not contain a class name.
+  object_contents:
+    seq:
+      - id: colon1
+        contents: ':'
+      - id: class_name
+        type: size_prefixed_quoted_string
+        doc: The name of the object's class.
+      - id: colon2
+        contents: ':'
+      - id: properties
+        type: size_prefixed_mapping
+        doc: The object's properties. Keys ust be of type `string`, values may have any type.
+    doc: The contents of an object value serialized in the default format. Unlike its PHP 3 counterpart, it contains a class name.
+  custom_serialized_object_contents:
+    seq:
+      - id: colon1
+        contents: ':'
+      - id: class_name
+        type: size_prefixed_quoted_string
+        doc: The name of the object's class.
+      - id: colon2
+        contents: ':'
+      - id: size_dec
+        type: str
+        terminator: 0x3a # ':'
+        doc: The size of the serialized data in bytes, in ASCII decimal. The braces are not counted in this size number.
+      - id: opening_brace
+        contents: '{'
+      - id: data
+        size: size
+        doc: |
+          The custom serialized data. The braces are not included.
+          
+          Although the surrounding braces make it look like a regular serialized object, this field is actually more similar to a string: it can contain arbitrary data that is not required to follow any common structure.
+      - id: closing_quote
+        contents: '}'
+    instances:
+      size:
+        value: size_dec.to_i
+        doc: The size of the serialized data in bytes, parsed as an integer. The braces are not counted in this size number.
+    doc: The contents of an object value that implements a custom serialized format using `Serializable`.


### PR DESCRIPTION
This adds specs for the following two formats, both from the PHP ecosystem:

* `serialization/php_serialized_value`: PHP's serialized data format, as used by the standard `serialize` and `unserialize` functions.
* `archive/phar_without_stub`: The phar (PHP Archive) format, used to package a PHP application or library into a single, self-contained, and optionally executable archive.
  * This spec does not handle the executable PHP stub that precedes every phar archive, because it is currently not possible to express multi-byte string terminators in Kaitai Struct (see kaitai-io/kaitai_struct#158 and kaitai-io/kaitai_struct#538). All other parts of the format are fully specced, and the format of the executable PHP stub is described in text form in the `doc` block.

I'm submitting these as one PR, because the phar format loosely depends on the PHP serialization format (some optional fields in the phar format contain serialized PHP data).