### PR TITLE
Extend BMP format support

### DIFF
--- a/image/bmp.ksy
+++ b/image/bmp.ksy
@@ -91,10 +91,10 @@ doc: |
       * BITMAPV4HEADER (WIN4XBITMAPHEADER)
 
 seq:
-  - id: file_header
+  - id: file_hdr
     type: file_header
   - id: dib_info
-    size: file_header.ofs_bitmap - 14 # 14 = file_header._sizeof (TODO: replace when KSC 0.9 is released)
+    size: file_hdr.ofs_bitmap - 14 # 14 = file_hdr._sizeof (TODO: replace when KSC 0.9 is released)
     type: bitmap_info
   - id: bitmap
     type: bitmap
@@ -406,7 +406,7 @@ types:
           or _parent.bitmap_v4_ext.color_space_type == color_space::profile_embedded
       profile_data:
         io: _root._io
-        pos: 14 + ofs_profile # 14 = _root.file_header._sizeof
+        pos: 14 + ofs_profile # 14 = _root.file_hdr._sizeof
         size: len_profile
         type:
           switch-on: _parent.bitmap_v4_ext.color_space_type == color_space::profile_linked

--- a/image/bmp.ksy
+++ b/image/bmp.ksy
@@ -104,6 +104,8 @@ types:
     doc: |
       Replace with an opaque type if you care about the pixels.
       You can look at an example of a JavaScript implementation: https://github.com/generalmimon/bmptool/blob/master/src/Bitmap.js
+
+      There is a proposal for adding bitmap data type to Kaitai Struct: https://github.com/kaitai-io/kaitai_struct/issues/188
   file_header:
     -orig-id: BITMAPFILEHEADER
     doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapfileheader

--- a/image/bmp.ksy
+++ b/image/bmp.ksy
@@ -17,26 +17,95 @@ meta:
   endian: le
   license: CC0-1.0
   ks-version: 0.8
+doc: |
+  The **BMP file format**, also known as **bitmap image file** or **device independent
+  bitmap (DIB) file format** or simply a **bitmap**, is a raster graphics image file
+  format used to store bitmap digital images, independently of the display
+  device (such as a graphics adapter), especially on Microsoft Windows
+  and OS/2 operating systems.
+
+  ## Samples
+
+  Great collection of various BMP sample files:
+  [**BMP Suite Image List**](
+    http://entropymine.com/jason/bmpsuite/bmpsuite/html/bmpsuite.html
+  ) (by Jason Summers)
+
+  If only there was such a comprehensive sample suite for every file format! It's like
+  a dream for every developer of any binary file format parser. It contains a lot of
+  different types and variations of BMP files, even the tricky ones, where it's not clear
+  from the specification how to deal with them (marked there as "**q**uestionable").
+
+  If you make a program which will be able to read all the "**g**ood" and "**q**uestionable"
+  BMP files and won't crash on the "**b**ad" ones, it will definitely have one of the most
+  extensive support of BMP files in the universe!
+
+  ## BITMAPV2INFOHEADER and BITMAPV3INFOHEADER
+
+  A beneficial discussion on Adobe forum (archived):
+  [**Invalid BMP Format with Alpha channel**](
+    https://web.archive.org/web/20150127132443/https://forums.adobe.com/message/3272950
+  )
+
+  In 2010, someone noticed that Photoshop generated BMP with an odd type of header. There wasn't
+  any documentation available for this header at the time (and still isn't).
+  However, Chris Cox (former Adobe employee) claimed that they hadn't invented any type
+  of proprietary header and everything they were writing was taken directly
+  from the Microsoft documentation.
+
+  It showed up that the unknown header was called BITMAPV3INFOHEADER.
+  Although Microsoft has apparently requested and verified the use of the header,
+  the documentation on MSDN has probably got lost and they have probably
+  forgotten about this type of header.
+
+  This is the only source I could find about these structures, so we could't rely
+  on it so much, but I think supporting them as a read-only format won't harm anything.
+  Due to the fact that it isn't documented anywhere else, most applications don't support it.
+
+  All Windows headers at once (including mentioned BITMAPV2INFOHEADER and BITMAPV3INFOHEADER):
+  ![Bitmap headers overview](
+    https://forums.adobe.com/servlet/JiveServlet/showImage/2-3273299-47801/BMP_Headers.png
+  )
+
+  ## Specs
+   * [Bitmap Storage (Windows Dev Center)](
+       https://docs.microsoft.com/en-us/windows/win32/gdi/bitmap-storage
+     )
+      * BITMAPFILEHEADER
+      * BITMAPINFOHEADER
+      * BITMAPV4HEADER
+      * BITMAPV5HEADER
+   * [OS/2 Bitmap File Format](
+        https://www.fileformat.info/format/os2bmp/egff.htm
+     )
+      * BITMAPFILEHEADER (OS2BMPFILEHEADER)
+      * BITMAPCOREHEADER (OS21XBITMAPHEADER)
+      * OS22XBITMAPHEADER
+   * [Microsoft Windows Bitmap](
+        http://netghost.narod.ru/gff/graphics/summary/micbmp.htm
+     )
+      * BITMAPFILEHEADER (WINBMPFILEHEADER)
+      * BITMAPCOREHEADER (WIN2XBITMAPHEADER)
+      * BITMAPINFOHEADER (WINNTBITMAPHEADER)
+      * BITMAPV4HEADER (WIN4XBITMAPHEADER)
+
 seq:
   - id: file_hdr
     type: file_header
-  - id: len_dib_header
-    type: s4
-  - id: dib_header
-    size: len_dib_header - 4
-    type:
-      switch-on: len_dib_header
-      cases:
-        12: bitmap_core_header
-        40: bitmap_info_header
-        104: bitmap_core_header # FIXME, should use BITMAPV4HEADER
-        124: bitmap_core_header # FIXME, should use BITMAPV5HEADER
+  - id: dib_info
+    size: file_hdr.ofs_bitmap - 14 # 14 = file_hdr._sizeof (TODO: replace when KSC 0.9 is released)
+    type: bitmap_info
+  - id: image
+    type: image
+    size-eos: true
 types:
+  image:
+    doc: Replace with an opaque type if you care about the pixels.
   file_header:
     -orig-id: BITMAPFILEHEADER
-    doc-ref: https://msdn.microsoft.com/en-us/library/dd183374.aspx
+    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapfileheader
     seq:
-      - id: magic
+      - id: file_type
         -orig-id: bfType
         contents: "BM"
       - id: len_file
@@ -52,53 +121,114 @@ types:
         -orig-id: bfOffBits
         type: s4
         doc: Offset to actual raw pixel data of the image
-  bitmap_core_header:
-    -orig-id: BITMAPCOREHEADER
-    doc-ref: https://msdn.microsoft.com/en-us/library/dd183372.aspx
+  bitmap_info:
+    -orig-id: BITMAPINFO
+    doc-ref: https://docs.microsoft.com/cs-cz/windows/win32/api/wingdi/ns-wingdi-bitmapinfo
     seq:
-      - id: image_width
-        -orig-id: bcWidth
-        type: u2
-        doc: Image width, px
-      - id: image_height
-        -orig-id: bcHeight
-        type: u2
-        doc: Image height, px
-      - id: num_planes
-        -orig-id: bcPlanes
-        type: u2
-        doc: Number of planes for target device, must be 1
-      - id: bits_per_pixel
-        -orig-id: bcBitCount
-        type: u2
-        doc: Number of bits per pixel that image buffer uses (1, 4, 8, or 24)
-  bitmap_info_header:
-    -orig-id: BITMAPINFOHEADER
-    doc-ref: https://msdn.microsoft.com/en-us/library/dd183376.aspx
+      - id: header_size
+        type: u4
+      - id: header
+        -orig-id: bmciHeader
+        type: bitmap_header(header_size)
+        size: header_size - 4
+      - id: color_mask
+        doc: Valid only for BITMAPINFOHEADER, in all headers extending it the masks are contained in the header itself.
+        if:
+          not _io.eof and
+          (header.header_size == header_type::bitmap_info_header.to_i) and
+          header.bitmap_info_ext.compression == compressions::bitfields
+        type: color_mask(false)
+      - id: color_table
+        -orig-id: bmciColors
+        if: not _io.eof
+        type: 'color_table(
+            header.extends_bitmap_info,
+            header.extends_bitmap_info ? header.bitmap_info_ext.num_colors_used : 0
+          )'
+        size-eos: true
+
+  bitmap_header:
+    -orig-id: BITMAPCOREHEADER
+    doc-ref: https://docs.microsoft.com/cs-cz/windows/win32/api/wingdi/ns-wingdi-bitmapcoreheader
+    -orig-id: OS21XBITMAPHEADER
+    doc-ref: https://www.fileformat.info/format/os2bmp/egff.htm#OS2BMP-DMYID.3.1
+    params:
+      - id: header_size
+        type: u4
     seq:
       - id: image_width
         -orig-id: biWidth
-        type: u4
-      - id: image_height
+        doc: Image width, px
+        type:
+          switch-on: is_core_header
+          cases:
+            true: s2
+            false: s4
+      - id: image_height_raw
         -orig-id: biHeight
-        type: u4
+        doc: Image height, px (positive => bottom-up image, negative => top-down image)
+        type:
+          switch-on: is_core_header
+          cases:
+            true: s2
+            false: s4
       - id: num_planes
         -orig-id: biPlanes
+        doc: Number of planes for target device, must be 1
         type: u2
+        # valid: 1
       - id: bits_per_pixel
         -orig-id: biBitCount
+        doc: Number of bits per pixel that image buffer uses (1, 4, 8, 16, 24 or 32)
         type: u2
+      - id: bitmap_info_ext
+        if: extends_bitmap_info
+        type: bitmap_info_extension
+      - id: os2_2x_bitmap_ext
+        if: extends_os2_2x_bitmap
+        type: os2_2x_bitmap_extension
+      - id: bitmap_v4_ext
+        if: extends_bitmap_v4
+        type: bitmap_v4_extension
+      - id: bitmap_v5_ext
+        if: extends_bitmap_v5
+        type: bitmap_v5_extension
+    instances:
+      is_core_header:
+        value: header_size == header_type::bitmap_core_header.to_i
+      extends_bitmap_info:
+        value: header_size >= header_type::bitmap_info_header.to_i
+      extends_os2_2x_bitmap:
+        value: header_size == header_type::os2_2x_bitmap_header.to_i
+      extends_bitmap_v4:
+        value: header_size >= header_type::bitmap_v4_header.to_i
+      extends_bitmap_v5:
+        value: header_size >= header_type::bitmap_v5_header.to_i
+      image_height:
+        value: 'image_height_raw < 0 ? -image_height_raw : image_height_raw'
+      bottom_up:
+        value: image_height > 0
+  bitmap_info_extension:
+    -orig-id: BITMAPINFOHEADER
+    doc-ref: https://docs.microsoft.com/en-us/previous-versions/dd183376(v=vs.85)
+    seq:
       - id: compression
         -orig-id: biCompression
+        if: not extends_os2_2x_bitmap
         type: u4
         enum: compressions
+      - id: os2_compression
+        -orig-id: Compression
+        if: extends_os2_2x_bitmap
+        type: u4
+        enum: os2_compressions
       - id: len_image
         -orig-id: biSizeImage
         type: u4
-      - id: x_px_per_m
+      - id: x_resolution
         -orig-id: biXPelsPerMeter
         type: u4
-      - id: y_px_per_m
+      - id: y_resolution
         -orig-id: biYPelsPerMeter
         type: u4
       - id: num_colors_used
@@ -107,13 +237,180 @@ types:
       - id: num_colors_important
         -orig-id: biClrImportant
         type: u4
-instances:
-  image:
-    pos: file_hdr.ofs_bitmap
-    size-eos: true
+      - id: color_mask
+        if: 'hdr_size == header_type::bitmap_v2_info_header.to_i or
+          hdr_size == header_type::bitmap_v3_info_header.to_i'
+        type: color_mask(hdr_size == header_type::bitmap_v3_info_header.to_i)
+    instances:
+      hdr_size:
+        value: _parent.header_size
+      extends_os2_2x_bitmap:
+        value: _parent.extends_os2_2x_bitmap
+  os2_2x_bitmap_extension:
+    -orig-id: OS22XBITMAPHEADER
+    doc-ref: https://www.fileformat.info/format/os2bmp/egff.htm#OS2BMP-DMYID.3.2
+    seq:
+      - id: units
+        type: u2
+      - id: reserved
+        type: u2
+      - id: recording
+        doc: |
+          Specifies how the bitmap scan lines are stored.
+          The only valid value for this field is 0, indicating that the bitmap is
+          stored from left to right and from the bottom up.
+        type: u2
+        # valid: 0
+      - id: rendering
+        doc: Specifies the halftoning algorithm used on the bitmap data.
+        type: u2
+        enum: os2_rendering
+      - id: size1
+        doc: |
+          rendering == os2_rendering::error_diffusion
+            => error damping as a percentage in the range 0 through 100
+          rendering == os2_rendering::panda or rendering == os2_rendering::super_circle
+            => X dimension of the pattern used in pixels
+        type: u4
+      - id: size2
+        doc: |
+          rendering == os2_rendering::error_diffusion
+            => not used
+          rendering == os2_rendering::panda or rendering == os2_rendering::super_circle
+            => Y dimension of the pattern used in pixels
+        type: u4
+      - id: color_encoding
+        doc: |
+          Specifies the color model used to describe the bitmap data.
+          The only valid value is 0, indicating the RGB encoding scheme.
+        type: u4
+      - id: identifier
+        doc: Application-specific value
+        type: u4
+
+  bitmap_v4_extension:
+    -orig-id: BITMAPV4HEADER
+    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv4header
+    seq:
+      - id: color_mask
+        type: color_mask(true)
+      - id: color_space_type
+        -orig-id: bV4CSType
+        type: u4
+        enum: color_space
+      - id: endpoints
+        -orig-id: bV4Endpoints
+        type: cie_xyz
+        repeat: expr
+        repeat-expr: 3
+      - id: gamma_red
+        -orig-id: bV4GammaRed
+        type: fixed_point_16_dot_16
+      - id: gamma_blue
+        -orig-id: bV4GammaGreen
+        type: fixed_point_16_dot_16
+      - id: gamma_green
+        -orig-id: bV4GammaBlue
+        type: fixed_point_16_dot_16
+      
+  cie_xyz:
+    -orig-id: CIEXYZ
+    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-ciexyz
+    seq:
+      - id: x
+        type: fixed_point_2_dot_30
+      - id: y
+        type: fixed_point_2_dot_30
+      - id: z
+        type: fixed_point_2_dot_30
+  
+  bitmap_v5_extension:
+    -orig-id: BITMAPV5HEADER
+    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header
+    seq:
+      - id: intent
+        -orig-id: bV5Intent
+        type: u4
+        enum: intent
+      - id: offset_profile
+        doc: The offset, in bytes, from the beginning of the BITMAPV5HEADER structure to the start of the profile data.
+        -orig-id: bV5ProfileData
+        type: u4
+      - id: len_profile
+        -orig-id: bV5ProfileSize
+        type: u4
+      - id: reserved
+        -orig-id: bV5Reserved
+        type: u4
+
+  color_table:
+    params:
+      - id: has_reserved_field
+        type: bool
+      - id: colors_num
+        doc: |
+          If equal to 0, the pallete should contain as many colors as can fit into the pixel value
+          according to the `bits_per_pixel` field (if `bits_per_pixel` = 8, then the pixel can
+          represent 2 ** 8 = 256 values, so exactly 256 colors should be present). For more flexibility,
+          it reads as many colors as it can until EOS is reached (and the image data begin).
+        type: u4
+    seq:
+      - id: colors
+        type: rgb_record(has_reserved_field)
+        repeat: until
+        repeat-until: _io.eof or _index == colors_num
+  color_mask:
+    params:
+      - id: has_alpha_mask
+        type: bool
+    seq:
+      - id: red_mask
+        type: u4
+      - id: green_mask
+        type: u4
+      - id: blue_mask
+        type: u4
+      - id: alpha_mask
+        if: has_alpha_mask
+        type: u4
+  rgb_record:
+    -orig-id: RGB_TRIPLE
+    -orig-id: RGB_QUAD
+    params:
+      - id: has_reserved_field
+        type: bool
+    seq:
+      - id: blue
+        type: u1
+      - id: green
+        type: u1
+      - id: red
+        type: u1
+      - id: reserved
+        if: has_reserved_field
+        type: u1
+    -webide-representation: "rgb({red:dec}, {green:dec}, {blue:dec})"
+# Common types
+  fixed_point_2_dot_30:
+    -orig-id: FXPT2DOT30
+    seq:
+      - id: raw
+        type: u4
+    instances:
+      value:
+        value: raw.as<f4> / (1 << 30)
+    -webide-representation: "{value}"
+  fixed_point_16_dot_16:
+    seq:
+      - id: raw
+        type: u4
+    instances:
+      value:
+        value: raw.as<f4> / (1 << 16)
+    -webide-representation: "{value}"
 enums:
   compressions:
-    # https://msdn.microsoft.com/en-us/library/cc250415.aspx
+    # https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header (search for bV5Compression)
     0:
       id: rgb
       -orig-id: BI_RGB
@@ -137,12 +434,88 @@ enums:
       id: png
       -orig-id: BI_PNG
       doc: BMP file includes whole PNG file in image buffer
-    0xb:
-      id: cmyk
-      -orig-id: BI_CMYK
-    0xc:
-      id: cmyk_rle8
-      -orig-id: BI_CMYKRLE8
-    0xd:
-      id: cmyk_rle4
-      -orig-id: BI_CMYKRLE4
+  os2_compressions:
+    # https://www.fileformat.info/format/os2bmp/egff.htm#OS2BMP-DMYID.3.2
+    0:
+      id: rgb
+    1:
+      id: rle8
+    2:
+      id: rle4
+    3:
+      id: huffman_1d
+      doc: Huffman 1D compression (also known as CCITT Group 3 One-Dimensional (G31D))
+    4:
+      id: rle24
+      doc: RLE compression, 24 bits per pixel
+  os2_rendering:
+    0:
+      id: no_halftoning
+    1:
+      id: error_diffusion
+    2:
+      id: panda
+      doc: Processing Algorithm for Noncoded Document Acquisition (PANDA)
+    3:
+      id: super_circle
+
+  color_space:
+    # https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header#members
+  # For BITMAPV4HEADER:
+    0:
+      id: calibrated_rgb
+      -orig-id: LCS_CALIBRATED_RGB
+      doc: This value implies that endpoints and gamma values are given in the appropriate fields.
+    0x73524742: # 'sRGB'
+      id: s_rgb
+      -orig-id: LCS_sRGB
+      doc: Specifies that the bitmap is in sRGB color space.
+    0x57696e20: # 'Win '
+      id: windows
+      -orig-id: LCS_WINDOWS_COLOR_SPACE
+      doc: This value indicates that the bitmap is in the system default color space, sRGB.
+  # For BITMAPV5HEADER:
+    0x4c494e4b: # 'LINK'
+      id: profile_linked
+      -orig-id: PROFILE_LINKED
+      doc: |
+        This value indicates that bV5ProfileData points to the file name of the profile
+        to use (gamma and endpoints values are ignored).
+
+        If a profile is linked, the path of the profile can be any fully qualified name
+        (including a network path) that can be opened using the Win32 CreateFile function.
+    0x4d424544: # 'MBED'
+      id: profile_embedded
+      -orig-id: PROFILE_EMBEDDED
+      doc: |
+        This value indicates that bV5ProfileData points to a memory buffer that contains
+        the profile to be used (gamma and endpoints values are ignored).
+  intent:
+    # https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header#members
+    8:
+      id: abs_colorimetric
+      doc: Maintains the white point. Matches the colors to their nearest color in the destination gamut.
+      -orig-id: LCS_GM_ABS_COLORIMETRIC
+    1:
+      id: business
+      doc: Maintains saturation. Used for business charts and other situations in which undithered colors are required.
+      -orig-id: LCS_GM_BUSINESS
+    2:
+      id: graphics
+      doc: Maintains colorimetric match. Used for graphic designs and named colors.
+      -orig-id: LCS_GM_GRAPHICS
+    4:
+      id: images
+      doc: Maintains contrast. Used for photographs and natural images.
+      -orig-id: LCS_GM_IMAGES
+
+  header_type:
+    # https://forums.adobe.com/servlet/JiveServlet/showImage/2-3273299-47801/BMP_Headers.png
+    12: bitmap_core_header
+    40: bitmap_info_header
+    52: bitmap_v2_info_header
+    56: bitmap_v3_info_header
+    64: os2_2x_bitmap_header
+    108: bitmap_v4_header
+    124: bitmap_v5_header
+

--- a/image/bmp.ksy
+++ b/image/bmp.ksy
@@ -127,7 +127,7 @@ types:
         doc: Offset to actual raw pixel data of the image
   bitmap_info:
     -orig-id: BITMAPINFO
-    doc-ref: https://docs.microsoft.com/cs-cz/windows/win32/api/wingdi/ns-wingdi-bitmapinfo
+    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfo
     seq:
       - id: header_size
         type: u4
@@ -202,7 +202,7 @@ types:
       - BITMAPCOREHEADER
       - OS21XBITMAPHEADER
     doc-ref:
-      - https://docs.microsoft.com/cs-cz/windows/win32/api/wingdi/ns-wingdi-bitmapcoreheader
+      - https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapcoreheader
       - https://www.fileformat.info/format/os2bmp/egff.htm#OS2BMP-DMYID.3.1
     params:
       - id: header_size
@@ -413,7 +413,7 @@ types:
           cases:
             true: strz
         if: has_profile
-        doc-ref: https://docs.microsoft.com/cs-cz/previous-versions/windows/desktop/wcs/using-structures-in-wcs-1-0 "If the profile is embedded,
+        doc-ref: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/wcs/using-structures-in-wcs-1-0 "If the profile is embedded,
           profile data is the actual profile, and if it is linked, the profile data is the
           null-terminated file name of the profile. This cannot be a Unicode string. It must be composed exclusively
           of characters from the Windows character set (code page 1252)."

--- a/image/bmp.ksy
+++ b/image/bmp.ksy
@@ -16,7 +16,7 @@ meta:
     wikidata: Q192869
   endian: le
   license: CC0-1.0
-  ks-version: 0.8
+  ks-version: 0.9
   # ks-opaque-types: true # uncomment if you provide an opaque type `bitmap` for bitmap data
 doc: |
   The **BMP file format**, also known as **bitmap image file** or **device independent

--- a/image/bmp.ksy
+++ b/image/bmp.ksy
@@ -94,7 +94,7 @@ seq:
   - id: file_hdr
     type: file_header
   - id: dib_info
-    size: file_hdr.ofs_bitmap - 14 # 14 = file_hdr._sizeof (TODO: replace when KSC 0.9 is released)
+    size: file_hdr.ofs_bitmap - file_hdr._sizeof
     type: bitmap_info
   - id: bitmap
     type: bitmap
@@ -408,7 +408,7 @@ types:
           or _parent.bitmap_v4_ext.color_space_type == color_space::profile_embedded
       profile_data:
         io: _root._io
-        pos: 14 + ofs_profile # 14 = _root.file_hdr._sizeof
+        pos: _root.file_hdr._sizeof + ofs_profile
         size: len_profile
         type:
           switch-on: _parent.bitmap_v4_ext.color_space_type == color_space::profile_linked

--- a/image/bmp.ksy
+++ b/image/bmp.ksy
@@ -129,12 +129,12 @@ types:
     -orig-id: BITMAPINFO
     doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfo
     seq:
-      - id: header_size
+      - id: len_header
         type: u4
       - id: header
         -orig-id: bmciHeader
-        size: header_size - 4
-        type: bitmap_header(header_size)
+        size: len_header - 4
+        type: bitmap_header(len_header)
       - id: color_mask
         type: color_mask(header.bitmap_info_ext.compression == compressions::alpha_bitfields)
         if: not _io.eof and is_color_mask_here
@@ -150,7 +150,7 @@ types:
     instances:
       is_color_mask_here:
         value: >-
-          header.header_size == header_type::bitmap_info_header.to_i
+          header.len_header == header_type::bitmap_info_header.to_i
             and (header.bitmap_info_ext.compression == compressions::bitfields or header.bitmap_info_ext.compression == compressions::alpha_bitfields)
       is_color_mask_given:
         value: >-
@@ -205,7 +205,7 @@ types:
       - https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapcoreheader
       - https://www.fileformat.info/format/os2bmp/egff.htm#OS2BMP-DMYID.3.1
     params:
-      - id: header_size
+      - id: len_header
         type: u4
     seq:
       - id: image_width
@@ -237,7 +237,7 @@ types:
         type: bitmap_info_extension
         if: extends_bitmap_info
       - id: color_mask
-        type: color_mask(header_size != header_type::bitmap_v2_info_header.to_i)
+        type: color_mask(len_header != header_type::bitmap_v2_info_header.to_i)
         if: is_color_mask_here
       - id: os2_2x_bitmap_ext
         type: os2_2x_bitmap_extension
@@ -250,22 +250,22 @@ types:
         if: extends_bitmap_v5
     instances:
       is_core_header:
-        value: header_size == header_type::bitmap_core_header.to_i
+        value: len_header == header_type::bitmap_core_header.to_i
       extends_bitmap_info:
-        value: header_size >= header_type::bitmap_info_header.to_i
+        value: len_header >= header_type::bitmap_info_header.to_i
       extends_os2_2x_bitmap:
-        value: header_size == header_type::os2_2x_bitmap_header.to_i
+        value: len_header == header_type::os2_2x_bitmap_header.to_i
       extends_bitmap_v4:
-        value: header_size >= header_type::bitmap_v4_header.to_i
+        value: len_header >= header_type::bitmap_v4_header.to_i
       extends_bitmap_v5:
-        value: header_size >= header_type::bitmap_v5_header.to_i
+        value: len_header >= header_type::bitmap_v5_header.to_i
       image_height:
         value: 'image_height_raw < 0 ? -image_height_raw : image_height_raw'
       bottom_up:
         value: image_height_raw > 0
       is_color_mask_here:
-        value: header_size == header_type::bitmap_v2_info_header.to_i
-          or header_size == header_type::bitmap_v3_info_header.to_i
+        value: len_header == header_type::bitmap_v2_info_header.to_i
+          or len_header == header_type::bitmap_v3_info_header.to_i
           or extends_bitmap_v4
       uses_fixed_palette:
         value: not (bits_per_pixel == 16 or bits_per_pixel == 24 or bits_per_pixel == 32)


### PR DESCRIPTION
Current BMP spec in formats repository is somewhat rudimentary, it is not very much usable. I tried to improve that.

Every BMP file contains a DIB header (bitmap information header) part. There are several different variants. Every of them has a `header_size` field in the beginning, which is used for determining which header is present in the image. 

The existing implementation advised to switch over this field and select appropriate type representing the particular header. Although it seems to make sense, it complicates the access to common properties (e.g. width and height). To access width in the header, you would have to do this:
```yaml
instances:
  image_width:
    value: >-
      len_dib_header == header_type::bitmap_core_header.to_i ?
        header.dib_header.as<bitmap_core_header>.width :
        len_dib_header == header_type::bitmap_info_header.to_i ?
          header.dib_header.as<bitmap_info_header>.width :
          len_dib_header == header_type::bitmap_v4_header.to_i ?
            header.dib_header.as<bitmap_v4_header>.width :
            ... ?
              ... :
              0
```
The headers don't contain completely distinct fields, they are extending each other. The new implementation takes advantage of this: instead of rebuilding each header from nothing, it consists of several extensions that form together the required header. For example, if the present header is of type `BITMAPV4HEADER`, it will contain the fields from `BITMAPCOREHEADER` (these are inlined in `bitmap_header` type), `bitmap_info_extension` and `bitmap_v4_extension`.

Here is a diagram which shows supported DIB headers and their KSY type counterpart. There is a dashed line from `BITMAPCOREHEADER` to `BITMAPINFOHEADER`, because `BITMAPCOREHEADER` uses 16-bit integers for image width and height, while `BITMAPINFOHEADER` and all headers extending it use 32-bit integers (that's where the "+ 4" came from).
![The DIB headers diagram](https://user-images.githubusercontent.com/47499687/66706384-194af000-ed32-11e9-8d8a-99447e3e382f.gif)
