### PR TITLE
add padding in udp_datagram.ksy

### DIFF
--- a/network/udp_datagram.ksy
+++ b/network/udp_datagram.ksy
@@ -21,4 +21,7 @@ seq:
   - id: checksum
     type: u2
   - id: body
+    size: length - 8
+  - id: padding
     size-eos: true
+

--- a/network/udp_datagram.ksy
+++ b/network/udp_datagram.ksy
@@ -22,6 +22,3 @@ seq:
     type: u2
   - id: body
     size: length - 8
-  - id: padding
-    size-eos: true
-


### PR DESCRIPTION
I propose to add padding to the `udp_datagram.ksy` since the `body` of `udp_datagram` is only of a specific length. Everything after the udp_datagram.body with size `length - 8` is actually no data.