### PR TITLE
Added check-errors to GH Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           name: log.json
           path: _build/target/log.json
+      - name: Check build
+        working-directory: _build
+        run: ./check-errors target/log.json
       - name: Build diagrams
         working-directory: _build
         run: ./build-diagrams target html


### PR DESCRIPTION
This adds rudimentary error checking (true or false => breaking or not breaking the build) into our CI PR process.