### PR TITLE
pickle: Terminate ops sequence with stop opcode

### DIFF
--- a/serialization/python_pickle.ksy
+++ b/serialization/python_pickle.ksy
@@ -39,8 +39,8 @@ seq:
   # TODO is there a way to declare PROTO is optional, but only valid at position 0?
   - id: ops
     type: op
-    repeat: eos
-  # TODO is there a way to declare a trailing STOP is required?
+    repeat: until
+    repeat-until: _.code == opcode::stop
 types:
   op:
     seq:


### PR DESCRIPTION
This allows multiple pickles to be read from a single stream, or for a
stream to contain data following a pickle. It also flags invalid pickles
that lack a stop op.