### PR TITLE
Add IEEE 802.1AD tpid to ethernet frame var1

### DIFF
--- a/network/ethernet_frame.ksy
+++ b/network/ethernet_frame.ksy
@@ -99,6 +99,8 @@ enums:
     0x0804: chaosnet
     0x0805: x_25_level_3
     0x0806: arp
+    0x08ff: ax_25
     0x8100: ieee_802_1q_tpid
     0x86dd: ipv6
     0x88a8: ieee_802_1ad_tpid
+    0x88F7: ptp


### PR DESCRIPTION
Hi,

I want to propose an extension of the ethernet_frame implementing the stacked VLAN tags according to 802.1AD (taken from https://en.wikipedia.org/wiki/IEEE_802.1ad). 

I have another variant of implementation, but I'm not sure, which is the better solution. Please take a look to https://github.com/kaitai-io/kaitai_struct_formats/pull/275

Best regards,
Martin