### PR TITLE
Use Pygments syntax highlighter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.x'
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
       - name: Install deps
         run: |
           sudo apt-get update
@@ -41,8 +44,6 @@ jobs:
           echo 'gem: --no-document' | sudo tee /etc/gemrc
           cd _build
           bundle install
-      - name: Install setuptools
-        run: python3 -m pip install --user setuptools
       - name: Install Pygments
         run: python3 -m pip install --user pygments
       - name: Install Graphviz lexer for Pygments

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,8 +46,7 @@ jobs:
       - name: Install Graphviz lexer for Pygments
         run: |
           git clone -b master --depth 1 https://github.com/nikeee/pygments-lexer-graphviz.git
-          cd pygments-lexer-graphviz/
-          sudo python setup.py develop
+          sudo python3 -m pip install --editable pygments-lexer-graphviz/
       - name: Build targets
         working-directory: _build
         run: ./build-target .. target

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,11 @@ jobs:
           echo 'gem: --no-document' | sudo tee /etc/gemrc
           cd _build
           bundle install
+          git clone -b 2.5.2 --depth 1 https://github.com/pygments/pygments.git
+          git clone -b master --depth 1 https://github.com/nikeee/pygments-lexer-graphviz.git
+          cd pygments-lexer-graphviz/
+          python setup.py develop
+          cd ../
       - name: Build targets
         working-directory: _build
         run: ./build-target .. target

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,9 @@ jobs:
           cd _build
           bundle install
       - name: Install Pygments
-        run: git clone -b 2.5.2 --depth 1 https://github.com/pygments/pygments.git
+        run: python3 -m pip install --user pygments
       - name: Install Graphviz lexer for Pygments
-        run: |
-          git clone -b master --depth 1 https://github.com/nikeee/pygments-lexer-graphviz.git
-          sudo python3 -m pip install --editable pygments-lexer-graphviz/
+        run: python3 -m pip install --user git+https://github.com/nikeee/pygments-lexer-graphviz.git@master
       - name: Build targets
         working-directory: _build
         run: ./build-target .. target

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           git clone -b master --depth 1 https://github.com/nikeee/pygments-lexer-graphviz.git
           cd pygments-lexer-graphviz/
-          python setup.py develop
+          sudo python setup.py develop
       - name: Build targets
         working-directory: _build
         run: ./build-target .. target

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,11 +41,13 @@ jobs:
           echo 'gem: --no-document' | sudo tee /etc/gemrc
           cd _build
           bundle install
-          git clone -b 2.5.2 --depth 1 https://github.com/pygments/pygments.git
+      - name: Install Pygments
+        run: git clone -b 2.5.2 --depth 1 https://github.com/pygments/pygments.git
+      - name: Install Graphviz lexer for Pygments
+        run: |
           git clone -b master --depth 1 https://github.com/nikeee/pygments-lexer-graphviz.git
           cd pygments-lexer-graphviz/
           python setup.py develop
-          cd ../
       - name: Build targets
         working-directory: _build
         run: ./build-target .. target

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ jobs:
           echo 'gem: --no-document' | sudo tee /etc/gemrc
           cd _build
           bundle install
+      - name: Install setuptools
+        run: python3 -m pip install --user setuptools
       - name: Install Pygments
         run: python3 -m pip install --user pygments
       - name: Install Graphviz lexer for Pygments

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           ruby-version: '2.x'
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.x'
+          python-version: '2.x'
       - name: Install deps
         run: |
           sudo apt-get update
@@ -45,9 +45,9 @@ jobs:
           cd _build
           bundle install
       - name: Install Pygments
-        run: python3 -m pip install --user pygments
+        run: python -m pip install --user pygments
       - name: Install Graphviz lexer for Pygments
-        run: python3 -m pip install --user git+https://github.com/nikeee/pygments-lexer-graphviz.git@master
+        run: python -m pip install --user git+https://github.com/nikeee/pygments-lexer-graphviz.git@master
       - name: Build targets
         working-directory: _build
         run: ./build-target .. target

--- a/_build/Gemfile
+++ b/_build/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'commonmarker'
+gem 'pygments.rb'

--- a/_build/build-html
+++ b/_build/build-html
@@ -12,12 +12,14 @@ require 'cgi'
 require 'set'
 
 require 'commonmarker'
+require 'pygments'
+Pygments.start 'pygments/'
 
 class FormatPagesGenerator
   LANGS = {
     'index' => {name: 'Overview'},
 
-    'cpp_stl' => {name: 'C++/STL'},
+    'cpp_stl' => {name: 'C++/STL', lexer: 'cpp'},
     'csharp' => {name: 'C#', ext: 'cs'},
     'graphviz' => {name: 'GraphViz', ext: 'dot'},
     'java' => {name: 'Java', ext: 'java'},
@@ -66,6 +68,8 @@ class FormatPagesGenerator
     FileUtils::mkdir_p(html_dir)
     @html_dir = File.realpath(html_dir)
 
+    File.write("#{@html_dir}/pygments-default.css", Pygments.css('.highlight'))
+
     @erb_header = erb('header')
     @erb_fheader = erb('format_header')
     @erb_base = erb('format_base')
@@ -80,7 +84,7 @@ class FormatPagesGenerator
       @erb_usage[lang] = erb("usage_#{lang}") if FileTest.exists?("#{fn}.html.erb")
     }
 
-    @base_url = '//kaitai.io/'
+    @base_url = 'https://kaitai.io/'
 
     @all = {}
     @by_cat = {}
@@ -141,6 +145,7 @@ class FormatPagesGenerator
         warn "#{file_id}: no license"
       end
 
+      yaml_html = Pygments.highlight(yaml_str, :lexer => 'yaml')
       format_name = get_format_name(meta)
       cur_lang = 'index'
       page_title = format_name + " format spec for Kaitai Struct"
@@ -167,7 +172,7 @@ class FormatPagesGenerator
         begin
           puts "    * reading source file #{out_dir}/#{path}"
           src = File.read("#{out_dir}/#{path}")
-          src = CGI::escape_html(src)
+          src = Pygments.highlight(src, :lexer => LANGS[cur_lang][:lexer] || cur_lang)
         rescue Errno::ENOENT
           puts "      ... not found!"
           src = nil

--- a/_build/format_base.html.erb
+++ b/_build/format_base.html.erb
@@ -11,6 +11,6 @@
     <div class="container">
         <h2>Format specification in Kaitai Struct YAML</h2>
 
-        <pre><code class="yaml"><%= CGI::escape_html(yaml_str) %></code></pre>
+        <%= yaml_html %>
     </div>
 </section>

--- a/_build/format_lang.html.erb
+++ b/_build/format_lang.html.erb
@@ -31,7 +31,7 @@
         </div>
 
         <div class="row">
-            <pre><code class="<%= cur_lang %>"><%= src[:src] %></code></pre>
+            <%= src[:src] %>
 
         </div>
         <% } %>

--- a/_build/header.html.erb
+++ b/_build/header.html.erb
@@ -16,8 +16,7 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 
   <link rel="stylesheet" href="<%= @base_url %>styles/main.css" type="text/css">
-
-  <link rel="stylesheet" href="<%= @base_url %>styles/highlight/default.css">
+  <link rel="stylesheet" href="../pygments-default.css" type="text/css">
   <style>
 .diagram-img {
     display: block;
@@ -47,8 +46,10 @@ section#format-index .row {
 }
 
   </style>
+<!--
   <script src="<%= @base_url %>js/highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>
+-->
 </head>
 <body data-spy="scroll" data-target="#main-navbar" data-offset="100">
 

--- a/_build/header.html.erb
+++ b/_build/header.html.erb
@@ -46,10 +46,6 @@ section#format-index .row {
 }
 
   </style>
-<!--
-  <script src="<%= @base_url %>js/highlight.pack.js"></script>
-  <script>hljs.initHighlightingOnLoad();</script>
--->
 </head>
 <body data-spy="scroll" data-target="#main-navbar" data-offset="100">
 


### PR DESCRIPTION
It seems to me that the quality of the syntax highlighting provided by highlight.js that we use now is quite limited, one can see many highlighting issues across the whole format gallery. We use quite a limited subset of YAML actively for KSY purposes, and yet this library has various problems with that. For example https://formats.kaitai.io/utf8_string/index.html, this is not exactly how it should look like.

So I propose switching to Pygments, as we use for the documentation (https://github.com/kaitai-io/kaitai_struct_doc/pull/34). I think for https://doc.kaitai.io/ it works quite well.