### PR TITLE
fix duplicate enums in elf kaitai-io#279

### DIFF
--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -640,18 +640,14 @@ enums:
     28: fini_arraysz     # Size in bytes of DT_FINI_ARRAY
     29: runpath          # Library search path
     30: flags            # Flags for the object being loaded
-    32: encoding         # Start of encoded range
     32: preinit_array    # Array with addresses of preinit fct
     33: preinit_arraysz  # Size in bytes of DT_PREINIT_ARRAY
     34: maxpostags       # Number used
-    0x6000000d: loos
     0x6000000d: sunw_auxiliary
-    0x6000000e: sunw_rtldinf
     0x6000000e: sunw_filter
     0x60000010: sunw_cap
     0x60000011: sunw_symtab
     0x60000012: sunw_symsz
-    0x60000013: sunw_encoding
     0x60000013: sunw_sortent
     0x60000014: sunw_symsort
     0x60000015: sunw_symsortsz
@@ -663,8 +659,6 @@ enums:
     0x6000001b: sunw_ldmach
     0x6000001d: sunw_capchainent
     0x6000001f: sunw_capchainsz
-    0x6ffff000: hios
-    0x6ffffd00: valrnglo
     0x6ffffdf5: gnu_prelinked   # Prelinking timestamp
     0x6ffffdf6: gnu_conflictsz  # Size of conflict section
     0x6ffffdf7: gnu_liblistsz   # Size of library list
@@ -676,7 +670,6 @@ enums:
     0x6ffffdfd: posflag_1       # Flags for DT_* entries, effecting the following DT_* entry.
     0x6ffffdfe: syminsz         # Size of syminfo table (in bytes)
     0x6ffffdff: syminent        # Entry size of syminfo
-    0x6ffffdff: valrnghi
     0x6ffffe00: addrrnglo
     0x6ffffef5: gnu_hash
     0x6ffffef6: tlsdesc_plt
@@ -689,7 +682,6 @@ enums:
     0x6ffffefd: pltpad
     0x6ffffefe: movetab
     0x6ffffeff: syminfo
-    0x6ffffeff: addrrnghi
     0x6ffffff0: versym
     0x6ffffff9: relacount
     0x6ffffffa: relcount
@@ -698,9 +690,7 @@ enums:
     0x6ffffffd: verdefnum
     0x6ffffffe: verneed
     0x6fffffff: verneednum
-    0x70000000: loproc
     0x70000001: sparc_register
     0x7ffffffd: auxiliary
     0x7ffffffe: used
     0x7fffffff: filter
-    0x7fffffff: hiproc

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -670,7 +670,6 @@ enums:
     0x6ffffdfd: posflag_1       # Flags for DT_* entries, effecting the following DT_* entry.
     0x6ffffdfe: syminsz         # Size of syminfo table (in bytes)
     0x6ffffdff: syminent        # Entry size of syminfo
-    0x6ffffe00: addrrnglo
     0x6ffffef5: gnu_hash
     0x6ffffef6: tlsdesc_plt
     0x6ffffef7: tlsdesc_got


### PR DESCRIPTION
- DT_ENCODING is not encoded into files, it's a special value used by tools.

REF: https://docs.oracle.com/cd/E19683-01/816-7529/chapter6-42444/index.html

- DT_LOOS and DT_HIOS
- DT_VALRNGLO and DT_VALRNGHI
- DT_ADDRRNGLO and DT_ADDRRNGHI
- DT_LOPROC and DT_HIPROC

These are not encoded into files, they're just hi/lo region values.

ref: https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter6-42444.html

- DT_SUNW_RTLDINF is for internal use and not encoded into files.

ref: https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter6-42444.html