### PR TITLE
DBF: field name ends with x\0

### DIFF
--- a/database/dbf.ksy
+++ b/database/dbf.ksy
@@ -90,7 +90,7 @@ types:
   field:
     seq:
       - id: name
-        type: str
+        type: strz
         encoding: ASCII
         size: 11
       - id: datatype


### PR DESCRIPTION
There is some disagreement in descriptions and the implementation:
```
0−10	Field name: a string from one to 10 characters of the "alnum" set and a terminating null character (HEX: 00), usually the extra space is filled with null characters.
```
From here: [https://ru.wikipedia.org/wiki/DBF#Описание_формата](https://ru.wikipedia.org/wiki/DBF#%D0%9E%D0%BF%D0%B8%D1%81%D0%B0%D0%BD%D0%B8%D0%B5_%D1%84%D0%BE%D1%80%D0%BC%D0%B0%D1%82%D0%B0)

and
```
0–10	11 bytes	Field name in ASCII (zero-filled)
```
From here: https://en.wikipedia.org/wiki/.dbf#Field_descriptor_array

But, it happens that the rest is clogged with spaces, and they are striped when reading.
I didn't understand how to add this to the description...