### PR TITLE
Added DIME message

### DIFF
--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -24,6 +24,7 @@ doc: |
 doc-ref: 
   - https://tools.ietf.org/html/draft-nielsen-dime-02
   - https://docs.microsoft.com/en-us/archive/msdn-magazine/2002/december/sending-files-attachments-and-soap-messages-via-dime
+  - http://imrannazar.com/Parsing-the-DIME-Message-Format
 seq:
   - id: records
     type: record
@@ -53,25 +54,35 @@ types:
     doc: each individual fragment of the message
     seq:
       - id: version
+        doc: DIME format version (always 1)
         type: b5
       - id: is_first_record
+        doc: Set if this is the first record in the message
         type: b1
       - id: is_last_record
+        doc: Set if this is the last record in the message
         type: b1
       - id: is_chunk_record
+        doc: Set if the file contained in this record is chunked into multiple records
         type: b1
       - id: type_format
+        doc: Indicates the structure and format of the value of the TYPE field
         enum: type_formats
         type: b4
       - id: reserved
+        doc: Reserved for future use
         type: b4
       - id: len_options
+        doc: Length of the Options field
         type: u2
       - id: len_id
+        doc: Length of the ID field
         type: u2
       - id: len_type
+        doc: Length of the Type field
         type: u2
       - id: len_data
+        doc: Length of the Data field
         type: u4
       - id: options
         size: len_options
@@ -79,16 +90,19 @@ types:
       - id: options_padding
         type: padding
       - id: id
+        doc: Unique identifier of the file (set in the first record of file)
         type: str
         size: len_id
       - id: id_padding
         type: padding
       - id: type
+        doc: Specified type in the format set with type_format
         type: str
         size: len_type
       - id: type_padding
         type: padding
       - id: data
+        doc: The file data
         size: len_data
       - id: data_padding
         type: padding

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -23,48 +23,48 @@ types:
   padding:
     doc: padding to the next 4-byte boundary
     seq:
-    - id: boundary_padding
-      size: (4 - _io.pos) % 4
+      - id: boundary_padding
+        size: (4 - _io.pos) % 4
   record:
     doc: each individual fragment of the message
     seq:
-    - id: version
-      type: b5
-    - id: is_first_record
-      type: b1
-    - id: is_last_record
-      type: b1
-    - id: is_chunck_record
-      type: b1
-    - id: type_format
-      enum: type_formats
-      type: b4
-    - id: reserved
-      type: b4
-    - id: len_options
-      type: u2
-    - id: len_id
-      type: u2
-    - id: len_type
-      type: u2
-    - id: len_data
-      type: u4
-    - id: options
-      size: len_options
-    - id: options_padding
-      type: padding
-    - id: id
-      size: len_id
-    - id: id_padding
-      type: padding
-    - id: type
-      size: len_type
-    - id: type_padding
-      type: padding
-    - id: data
-      size: len_data
-    - id: data_padding
-      type: padding
+      - id: version
+        type: b5
+      - id: is_first_record
+        type: b1
+      - id: is_last_record
+        type: b1
+      - id: is_chunck_record
+        type: b1
+      - id: type_format
+        enum: type_formats
+        type: b4
+      - id: reserved
+        type: b4
+      - id: len_options
+        type: u2
+      - id: len_id
+        type: u2
+      - id: len_type
+        type: u2
+      - id: len_data
+        type: u4
+      - id: options
+        size: len_options
+      - id: options_padding
+        type: padding
+      - id: id
+        size: len_id
+      - id: id_padding
+        type: padding
+      - id: type
+        size: len_type
+      - id: type_padding
+        type: padding
+      - id: data
+        size: len_data
+      - id: data_padding
+        type: padding
 enums:
   type_formats:
     0: unchanged

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -1,0 +1,61 @@
+meta:
+  id: dime_message
+  title: DIME (Direct Internet Message Encapsulation) Message
+  license: CC0-1.0
+  endian: be
+doc: |
+  Direct Internet Message Encapsulation (DIME)
+  is an old Microsoft specification for sending and receiving
+  SOAP messages along with additional attachments,
+  like binary files, XML fragments, and even other
+  SOAP messages, using standard transport protocols like HTTP.
+doc-ref: 
+  - http://xml.coverpages.org/draft-nielsen-dime-02.txt
+  - https://docs.microsoft.com/en-us/archive/msdn-magazine/2002/december/sending-files-attachments-and-soap-messages-via-dime
+seq:
+  - id: dime
+    type: message
+types:
+  message:
+    seq:
+    - id: message
+      type: record
+      repeat: eos
+  record:
+    seq:
+    - id: version
+      type: b5
+    - id: first_record
+      type: b1
+    - id: last_record
+      type: b1
+    - id: chunck_record
+      type: b1
+    - id: type_format
+      type: b4
+    - id: reserved
+      type: b4
+    - id: options_length
+      type: u2
+    - id: id_length
+      type: u2
+    - id: type_length
+      type: u2
+    - id: data_length
+      type: u4
+    - id: options
+      size: options_length
+    - id: options_padding
+      size: (4 - _io.pos) % 4
+    - id: id
+      size: id_length
+    - id: id_padding
+      size: (4 - _io.pos) % 4
+    - id: type
+      size: type_length
+    - id: type_padding
+      size: (4 - _io.pos) % 4
+    - id: data
+      size: data_length
+    - id: data_padding
+      size: (4 - _io.pos) % 4

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -23,7 +23,7 @@ types:
   padding:
     doc: padding to the next 4-byte boundary
     seq:
-    - id: padding
+    - id: boundary_padding
       size: (4 - _io.pos) % 4
   record:
     doc: each individual fragment of the message

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -1,7 +1,10 @@
 meta:
   id: dime_message
   title: DIME (Direct Internet Message Encapsulation) Message
+  xref:
+    wikidata: Q1227457
   license: CC0-1.0
+  bit-endian: be
   endian: be
 doc: |
   Direct Internet Message Encapsulation (DIME)
@@ -13,49 +16,61 @@ doc-ref:
   - http://xml.coverpages.org/draft-nielsen-dime-02.txt
   - https://docs.microsoft.com/en-us/archive/msdn-magazine/2002/december/sending-files-attachments-and-soap-messages-via-dime
 seq:
-  - id: dime
-    type: message
+  - id: records
+    type: record
+    repeat: eos
 types:
-  message:
+  padding:
+    doc: |
+      padding to the next 4-byte boundary
     seq:
-    - id: message
-      type: record
-      repeat: eos
+    - id: padding
+      size: ((_io.pos + 3) & ~3) - _io.pos
   record:
+    doc: |
+      each individual fragment of the message
     seq:
     - id: version
       type: b5
-    - id: first_record
+    - id: is_first_record
       type: b1
-    - id: last_record
+    - id: is_last_record
       type: b1
-    - id: chunck_record
+    - id: is_chunck_record
       type: b1
     - id: type_format
+      enum: type_formats
       type: b4
     - id: reserved
       type: b4
-    - id: options_length
+    - id: len_options
       type: u2
-    - id: id_length
+    - id: len_id
       type: u2
-    - id: type_length
+    - id: len_type
       type: u2
-    - id: data_length
+    - id: len_data
       type: u4
     - id: options
-      size: options_length
+      size: len_options
     - id: options_padding
-      size: (4 - _io.pos) % 4
+      type: padding
     - id: id
-      size: id_length
+      size: len_id
     - id: id_padding
-      size: (4 - _io.pos) % 4
+      type: padding
     - id: type
-      size: type_length
+      size: len_type
     - id: type_padding
-      size: (4 - _io.pos) % 4
+      type: padding
     - id: data
-      size: data_length
+      size: len_data
     - id: data_padding
-      size: (4 - _io.pos) % 4
+      type: padding
+enums:
+  type_formats:
+    0: unchanged
+    1: media_type
+    2: absolute_uri
+    3: unknown
+    4: none

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -34,13 +34,13 @@ types:
       - id: boundary_padding
         size: (- _io.pos) % 4
   option_field:
-    doc: the options field of the record
+    doc: the option field of the record
     seq:
       - id: option_elements
         type: option_element
         repeat: eos
   option_element:
-    doc: one element of the options field
+    doc: one element of the option field
     seq:
       - id: element_format
         type: u2

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -34,7 +34,7 @@ types:
         type: b1
       - id: is_last_record
         type: b1
-      - id: is_chunck_record
+      - id: is_chunk_record
         type: b1
       - id: type_format
         enum: type_formats

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -19,7 +19,7 @@ doc: |
   SOAP messages, using standard transport protocols like HTTP.
   
   Sample file: `curl -L
-  https://github.com/kaitai-io/kaitai_struct_formats/files/5890499/scanner.dump.gz
+  https://github.com/kaitai-io/kaitai_struct_formats/files/5894723/scanner_withoptions.dump.gz
   | gunzip -c > scanner.dump`
 doc-ref: 
   - https://tools.ietf.org/html/draft-nielsen-dime-02

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -21,14 +21,12 @@ seq:
     repeat: eos
 types:
   padding:
-    doc: |
-      padding to the next 4-byte boundary
+    doc: padding to the next 4-byte boundary
     seq:
     - id: padding
       size: (4 - _io.pos) % 4
   record:
-    doc: |
-      each individual fragment of the message
+    doc: each individual fragment of the message
     seq:
     - id: version
       type: b5

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -33,6 +33,21 @@ types:
     seq:
       - id: boundary_padding
         size: (- _io.pos) % 4
+  option_field:
+    doc: the options field of the record
+    seq:
+      - id: option_elements
+        type: option_element
+        repeat: eos
+  option_element:
+    doc: one element of the options field
+    seq:
+      - id: element_format
+        type: u2
+      - id: len_element
+        type: u2
+      - id: element_data
+        size: len_element
   record:
     doc: each individual fragment of the message
     seq:
@@ -59,6 +74,7 @@ types:
         type: u4
       - id: options
         size: len_options
+        type: option_field
       - id: options_padding
         type: padding
       - id: id

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -10,6 +10,7 @@ meta:
   license: CC0-1.0
   bit-endian: be
   endian: be
+  encoding: ASCII
 doc: |
   Direct Internet Message Encapsulation (DIME)
   is an old Microsoft specification for sending and receiving
@@ -78,10 +79,12 @@ types:
       - id: options_padding
         type: padding
       - id: id
+        type: str
         size: len_id
       - id: id_padding
         type: padding
       - id: type
+        type: str
         size: len_type
       - id: type_padding
         type: padding

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -21,7 +21,7 @@ doc: |
   https://github.com/kaitai-io/kaitai_struct_formats/files/5890499/scanner.dump.gz
   | gunzip -c > scanner.dump`
 doc-ref: 
-  - http://xml.coverpages.org/draft-nielsen-dime-02.txt
+  - https://tools.ietf.org/html/draft-nielsen-dime-02
   - https://docs.microsoft.com/en-us/archive/msdn-magazine/2002/december/sending-files-attachments-and-soap-messages-via-dime
 seq:
   - id: records

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -24,7 +24,7 @@ types:
     doc: padding to the next 4-byte boundary
     seq:
       - id: boundary_padding
-        size: (4 - _io.pos) % 4
+        size: (- _io.pos) % 4
   record:
     doc: each individual fragment of the message
     seq:

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -1,7 +1,11 @@
 meta:
   id: dime_message
   title: DIME (Direct Internet Message Encapsulation) Message
+  file-extension:
+    - dim
+    - dime
   xref:
+    mime: application/dime
     wikidata: Q1227457
   license: CC0-1.0
   bit-endian: be

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -25,7 +25,7 @@ types:
       padding to the next 4-byte boundary
     seq:
     - id: padding
-      size: ((_io.pos + 3) & ~3) - _io.pos
+      size: (4 - _io.pos) % 4
   record:
     doc: |
       each individual fragment of the message


### PR DESCRIPTION
Adding the old-school DIME (Direct Internet Message Encapsulation) format. Based on the 2002 Microsoft draft [here](http://xml.coverpages.org/draft-nielsen-dime-02.txt).

I was unsure on the folder where to put it, but settled on `network/`.

Thanks for this awesome project!