### PR TITLE
ELF: parse note sections + other ELF edits

### DIFF
--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -504,6 +504,7 @@ types:
             type: u4
           - id: name
             size: len_name
+            terminator: 0
             doc: |
               Although the ELF specification seems to hint that the `note_name` field
               is ASCII this isn't the case for Linux binaries that have a

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -506,7 +506,7 @@ types:
             size: name_size + (-name_size % 4)
             doc: |
               Although the ELF specification seems to hint that the note_name field
-              is ASCII this isn't the case on Linux binaries that have the
+              is ASCII this isn't the case for Linux binaries that have a
               .gnu.build.attributes section.
             doc-ref: https://fedoraproject.org/wiki/Toolchain/Watermark#Proposed_Specification_for_non-loaded_notes
           - id: note_description

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -20,7 +20,7 @@ meta:
     - executable
     - linux
   license: CC0-1.0
-  ks-version: 0.8
+  ks-version: 0.9
 doc-ref: https://sourceware.org/git/?p=glibc.git;a=blob;f=elf/elf.h;hb=HEAD
 seq:
   - id: magic
@@ -495,6 +495,14 @@ types:
             type: note_section_entry
             repeat: eos
       note_section_entry:
+        doc-ref:
+          - https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter6-18048.html
+          # The following source claims that note's `name` and `descriptor` should be padded
+          # to 8 bytes in 64-bit ELFs, not always to 4 - although this seems to be an idea of
+          # the original spec, it did not catch on in the real world and most implementations
+          # always use 4-byte alignment - see
+          # <https://fa.linux.kernel.narkive.com/2Za5xb58/patch-01-02-elf-always-define-elf-addr-t-in-linux-elf-h#post13>
+          - https://refspecs.linuxfoundation.org/elf/gabi4+/ch5.pheader.html#note_section
         seq:
           - id: len_name
             type: u4
@@ -517,6 +525,9 @@ types:
           - id: descriptor_padding
             size: -len_descriptor % 4
       relocation_section:
+        doc-ref:
+          - https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter6-54839.html
+          - https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.reloc.html
         params:
           - id: has_addend
             type: bool

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -405,6 +405,7 @@ types:
                 'sh_type::strtab': strings_struct
                 'sh_type::dynsym': dynsym_section
                 'sh_type::dynstr': strings_struct
+                'sh_type::note': note_section
           name:
             io: _root.header.strings._io
             pos: ofs_name
@@ -486,6 +487,23 @@ types:
             type: u8
           - id: size
             type: u8
+      note_section:
+        seq:
+          - id: entries
+            type: note_section_entry
+            repeat: eos
+      note_section_entry:
+        seq:
+          - id: name_size
+            type: u4
+          - id: description_size
+            type: u4
+          - id: note_type
+            type: u4
+          - id: note_name
+            size: "name_size % 4 == 0 ? name_size: name_size + (4 - name_size % 4)"
+          - id: note_description
+            size: "description_size % 4 == 0 ? description_size: description_size + (4 - description_size % 4)"
     instances:
       program_headers:
         pos: program_header_offset

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -498,7 +498,7 @@ types:
         seq:
           - id: len_name
             type: u4
-          - id: len_description
+          - id: len_descriptor
             type: u4
           - id: type
             type: u4
@@ -511,10 +511,10 @@ types:
             doc-ref: https://fedoraproject.org/wiki/Toolchain/Watermark#Proposed_Specification_for_non-loaded_notes
           - id: name_padding
             size: -len_name % 4
-          - id: description
-            size: len_description
-          - id: description_padding
-            size: -len_description % 4
+          - id: descriptor
+            size: len_descriptor
+          - id: descriptor_padding
+            size: -len_descriptor % 4
       relocation_section:
         params:
           - id: has_addend

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -500,16 +500,16 @@ types:
             type: u4
           - id: len_description
             type: u4
-          - id: note_type
+          - id: type
             type: u4
-          - id: note_name
+          - id: name
             size: len_name + (-len_name % 4)
             doc: |
               Although the ELF specification seems to hint that the `note_name` field
               is ASCII this isn't the case for Linux binaries that have a
               `.gnu.build.attributes` section.
             doc-ref: https://fedoraproject.org/wiki/Toolchain/Watermark#Proposed_Specification_for_non-loaded_notes
-          - id: note_description
+          - id: description
             size: len_description + (-len_description % 4)
       relocation_section:
         params:

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -406,8 +406,8 @@ types:
                 'sh_type::dynsym': dynsym_section
                 'sh_type::symtab': dynsym_section
                 'sh_type::note': note_section
-                'sh_type::rel': rel_section
-                'sh_type::rela': rela_section
+                'sh_type::rel': relocation_section(false)
+                'sh_type::rela': relocation_section(true)
           name:
             io: _root.header.strings._io
             pos: ofs_name
@@ -511,52 +511,35 @@ types:
             doc-ref: https://fedoraproject.org/wiki/Toolchain/Watermark#Proposed_Specification_for_non-loaded_notes
           - id: note_description
             size: description_size + (-description_size % 4)
-      rel_section:
+      relocation_section:
+        params:
+          - id: has_addend
+            type: bool
         seq:
           - id: entries
+            type: relocation_section_entry
+            repeat: eos
+      relocation_section_entry:
+        seq:
+          - id: offset
             type:
               switch-on: _root.bits
               cases:
-                'bits::b32': rel_section_entry32
-                'bits::b64': rel_section_entry64
-            repeat: eos
-      rel_section_entry32:
-        seq:
-          - id: rel_offs
-            type: u4
-          - id: rel_info
-            type: u4
-      rel_section_entry64:
-        seq:
-          - id: rel_offs
-            type: u8
-          - id: rel_info
-            type: u8
-      rela_section:
-        seq:
-          - id: entries
+                'bits::b32': u4
+                'bits::b64': u8
+          - id: info
             type:
               switch-on: _root.bits
               cases:
-                'bits::b32': rela_section_entry32
-                'bits::b64': rela_section_entry64
-            repeat: eos
-      rela_section_entry32:
-        seq:
-          - id: rela_offs
-            type: u4
-          - id: rela_info
-            type: u4
-          - id: rela_addend
-            type: s4
-      rela_section_entry64:
-        seq:
-          - id: rela_offs
-            type: u8
-          - id: rela_info
-            type: u8
-          - id: rela_addend
-            type: s8
+                'bits::b32': u4
+                'bits::b64': u8
+          - id: addend
+            type:
+              switch-on: _root.bits
+              cases:
+                'bits::b32': s4
+                'bits::b64': s8
+            if: _parent.has_addend
     instances:
       program_headers:
         pos: program_header_offset

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -505,9 +505,9 @@ types:
           - id: note_name
             size: name_size + (-name_size % 4)
             doc: |
-              Although the ELF specification seems to hint that the note_name field
+              Although the ELF specification seems to hint that the `note_name` field
               is ASCII this isn't the case for Linux binaries that have a
-              .gnu.build.attributes section.
+              `.gnu.build.attributes` section.
             doc-ref: https://fedoraproject.org/wiki/Toolchain/Watermark#Proposed_Specification_for_non-loaded_notes
           - id: note_description
             size: description_size + (-description_size % 4)

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -404,7 +404,6 @@ types:
                 'sh_type::dynamic': dynamic_section
                 'sh_type::strtab': strings_struct
                 'sh_type::dynsym': dynsym_section
-                'sh_type::dynstr': strings_struct
                 'sh_type::note': note_section
           name:
             io: _root.header.strings._io

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -503,14 +503,18 @@ types:
           - id: type
             type: u4
           - id: name
-            size: len_name + (-len_name % 4)
+            size: len_name
             doc: |
               Although the ELF specification seems to hint that the `note_name` field
               is ASCII this isn't the case for Linux binaries that have a
               `.gnu.build.attributes` section.
             doc-ref: https://fedoraproject.org/wiki/Toolchain/Watermark#Proposed_Specification_for_non-loaded_notes
+          - id: name_padding
+            size: -len_name % 4
           - id: description
-            size: len_description + (-len_description % 4)
+            size: len_description
+          - id: description_padding
+            size: -len_description % 4
       relocation_section:
         params:
           - id: has_addend

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -406,6 +406,8 @@ types:
                 'sh_type::dynsym': dynsym_section
                 'sh_type::symtab': dynsym_section
                 'sh_type::note': note_section
+                'sh_type::rel': rel_section
+                'sh_type::rela': rela_section
           name:
             io: _root.header.strings._io
             pos: ofs_name
@@ -509,6 +511,52 @@ types:
             doc-ref: https://fedoraproject.org/wiki/Toolchain/Watermark#Proposed_Specification_for_non-loaded_notes
           - id: note_description
             size: description_size + (-description_size % 4)
+      rel_section:
+        seq:
+          - id: entries
+            type:
+              switch-on: _root.bits
+              cases:
+                'bits::b32': rel_section_entry32
+                'bits::b64': rel_section_entry64
+            repeat: eos
+      rel_section_entry32:
+        seq:
+          - id: rel_offs
+            type: u4
+          - id: rel_info
+            type: u4
+      rel_section_entry64:
+        seq:
+          - id: rel_offs
+            type: u8
+          - id: rel_info
+            type: u8
+      rela_section:
+        seq:
+          - id: entries
+            type:
+              switch-on: _root.bits
+              cases:
+                'bits::b32': rela_section_entry32
+                'bits::b64': rela_section_entry64
+            repeat: eos
+      rela_section_entry32:
+        seq:
+          - id: rela_offs
+            type: u4
+          - id: rela_info
+            type: u4
+          - id: rela_addend
+            type: s4
+      rela_section_entry64:
+        seq:
+          - id: rela_offs
+            type: u8
+          - id: rela_info
+            type: u8
+          - id: rela_addend
+            type: s8
     instances:
       program_headers:
         pos: program_header_offset

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -404,6 +404,7 @@ types:
                 'sh_type::dynamic': dynamic_section
                 'sh_type::strtab': strings_struct
                 'sh_type::dynsym': dynsym_section
+                'sh_type::symtab': dynsym_section
                 'sh_type::note': note_section
           name:
             io: _root.header.strings._io

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -496,21 +496,21 @@ types:
             repeat: eos
       note_section_entry:
         seq:
-          - id: name_size
+          - id: len_name
             type: u4
-          - id: description_size
+          - id: len_description
             type: u4
           - id: note_type
             type: u4
           - id: note_name
-            size: name_size + (-name_size % 4)
+            size: len_name + (-len_name % 4)
             doc: |
               Although the ELF specification seems to hint that the `note_name` field
               is ASCII this isn't the case for Linux binaries that have a
               `.gnu.build.attributes` section.
             doc-ref: https://fedoraproject.org/wiki/Toolchain/Watermark#Proposed_Specification_for_non-loaded_notes
           - id: note_description
-            size: description_size + (-description_size % 4)
+            size: len_description + (-len_description % 4)
       relocation_section:
         params:
           - id: has_addend

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -501,9 +501,14 @@ types:
           - id: note_type
             type: u4
           - id: note_name
-            size: "name_size % 4 == 0 ? name_size: name_size + (4 - name_size % 4)"
+            size: name_size + (-name_size % 4)
+            doc: |
+              Although the ELF specification seems to hint that the note_name field
+              is ASCII this isn't the case on Linux binaries that have the
+              .gnu.build.attributes section.
+            doc-ref: https://fedoraproject.org/wiki/Toolchain/Watermark#Proposed_Specification_for_non-loaded_notes
           - id: note_description
-            size: "description_size % 4 == 0 ? description_size: description_size + (4 - description_size % 4)"
+            size: description_size + (-description_size % 4)
     instances:
       program_headers:
         pos: program_header_offset


### PR DESCRIPTION
Parse note sections in ELF files. The fields note_name and note_description are 4 byte aligned (hence the ugly calculation). Although the ELF specification seems to hint that the note_name field is ASCII I have found that this isn't the case on Linux binaries that have the .gnu.build.attributes section:

https://fedoraproject.org/wiki/Toolchain/Watermark#Proposed_Specification_for_non-loaded_notes

Fixes #253