### PR TITLE
add Huawei Bootloader packed image format

### DIFF
--- a/archive/android_bootldr_huawei.ksy
+++ b/archive/android_bootldr_huawei.ksy
@@ -56,14 +56,18 @@ types:
         type: image_hdr_entry
         repeat: eos
   image_hdr_entry:
+    -webide-representation: '{name} - o:{ofs_body}, s:{len_body}'
     seq:
       - id: name
         size: 72
         type: strz
         doc: partition name
-      - id: offset
+      - id: ofs_body
         type: u4
-        doc: partition offset from the beginning of the file
-      - id: size
+      - id: len_body
         type: u4
-        doc: partition size
+    instances:
+      body:
+        io: _root._io
+        pos: ofs_body
+        size: len_body

--- a/archive/android_bootldr_huawei.ksy
+++ b/archive/android_bootldr_huawei.ksy
@@ -25,17 +25,17 @@ seq:
     size: img_header.image_header_size
 types:
   header:
-     seq:
-        - id: magic
-          contents: [0x3c, 0xd6, 0x1a, 0xce]
-        - id: version
-          type: version
-        - id: image_version
-          size: 64
-        - id: meta_header_size
-          type: u2
-        - id: image_header_size
-          type: u2
+    seq:
+      - id: magic
+        contents: [0x3c, 0xd6, 0x1a, 0xce]
+      - id: version
+        type: version
+      - id: image_version
+        size: 64
+      - id: meta_header_size
+        type: u2
+      - id: image_header_size
+        type: u2
   version:
     seq:
       - id: major

--- a/archive/android_bootldr_huawei.ksy
+++ b/archive/android_bootldr_huawei.ksy
@@ -1,5 +1,5 @@
 meta:
-  id: android_img_huawei
+  id: android_bootldr_huawei
   title: Huawei Bootloader packed image format
   file-extension: img
   tags:

--- a/archive/android_bootldr_huawei.ksy
+++ b/archive/android_bootldr_huawei.ksy
@@ -11,7 +11,7 @@ doc: |
   Format of boot files found on certain Android devices from Huawei.
 
   Example device: Nexus 6P
-doc-ref: https://android.googlesource.com/device/huawei/angler/+/673cfb95bf3dccabae32b382bb17f2b08435b840/releasetools.py
+doc-ref: https://android.googlesource.com/device/huawei/angler/+/673cfb9/releasetools.py
 seq:
   - id: img_header
     type: header

--- a/archive/android_bootldr_huawei.ksy
+++ b/archive/android_bootldr_huawei.ksy
@@ -6,6 +6,9 @@ meta:
     - archive
     - android
   license: CC0-1.0
+  # The `releasetools.py` script is written for Python 2, where the default
+  # encoding is ASCII.
+  encoding: ASCII
   endian: le
 doc: |
   Format of `bootloader-*.img` files found in factory images of certain Android devices from Huawei:
@@ -34,6 +37,7 @@ types:
         type: version
       - id: image_version
         size: 64
+        type: strz
       - id: len_meta_header
         -orig-id: meta_hdr_sz
         type: u2
@@ -54,9 +58,8 @@ types:
   image_hdr_entry:
     seq:
       - id: name
-        type: strz
-        encoding: UTF-8
         size: 72
+        type: strz
         doc: partition name
       - id: offset
         type: u4

--- a/archive/android_bootldr_huawei.ksy
+++ b/archive/android_bootldr_huawei.ksy
@@ -19,6 +19,14 @@ doc: |
   [sample-angler]: https://androidfilehost.com/?fid=11410963190603870158 "bootloader-angler-angler-03.84.img"
   [others-angler]: https://androidfilehost.com/?w=search&s=bootloader-angler&type=files
 
+  All image versions can be found in factory images at
+  <https://developers.google.com/android/images> for the specific device. To
+  avoid having to download an entire ZIP archive when you only need one file
+  from it, install [remotezip](https://github.com/gtsystem/python-remotezip) and
+  use its [command line
+  tool](https://github.com/gtsystem/python-remotezip#command-line-tool) to list
+  members in the archive and then to download only the file you want.
+
 doc-ref: https://android.googlesource.com/device/huawei/angler/+/673cfb9/releasetools.py
 seq:
   - id: meta_header

--- a/archive/android_bootldr_huawei.ksy
+++ b/archive/android_bootldr_huawei.ksy
@@ -18,13 +18,15 @@ doc: |
 
 doc-ref: https://android.googlesource.com/device/huawei/angler/+/673cfb9/releasetools.py
 seq:
-  - id: img_header
-    type: header
-  - id: entries
-    type: entries
-    size: img_header.image_header_size
+  - id: meta_header
+    type: meta_hdr
+  - id: header_ext
+    size: meta_header.len_meta_header - meta_header._sizeof
+  - id: image_header
+    size: meta_header.len_image_header
+    type: image_hdr
 types:
-  header:
+  meta_hdr:
     seq:
       - id: magic
         contents: [0x3c, 0xd6, 0x1a, 0xce]
@@ -32,9 +34,11 @@ types:
         type: version
       - id: image_version
         size: 64
-      - id: meta_header_size
+      - id: len_meta_header
+        -orig-id: meta_hdr_sz
         type: u2
-      - id: image_header_size
+      - id: len_image_header
+        -orig-id: img_hdr_sz
         type: u2
   version:
     seq:
@@ -42,12 +46,12 @@ types:
         type: u2
       - id: minor
         type: u2
-  entries:
+  image_hdr:
     seq:
       - id: entries
-        type: entry
+        type: image_hdr_entry
         repeat: eos
-  entry:
+  image_hdr_entry:
     seq:
       - id: name
         type: strz

--- a/archive/android_bootldr_huawei.ksy
+++ b/archive/android_bootldr_huawei.ksy
@@ -8,9 +8,14 @@ meta:
   license: CC0-1.0
   endian: le
 doc: |
-  Format of boot files found on certain Android devices from Huawei.
+  Format of `bootloader-*.img` files found in factory images of certain Android devices from Huawei:
 
-  Example device: Nexus 6P
+  * Nexus 6P "angler": [sample][sample-angler] ([other samples][others-angler]),
+    [releasetools.py](https://android.googlesource.com/device/huawei/angler/+/cf92cd8/releasetools.py#29)
+
+  [sample-angler]: https://androidfilehost.com/?fid=11410963190603870158 "bootloader-angler-angler-03.84.img"
+  [others-angler]: https://androidfilehost.com/?w=search&s=bootloader-angler&type=files
+
 doc-ref: https://android.googlesource.com/device/huawei/angler/+/673cfb9/releasetools.py
 seq:
   - id: img_header

--- a/archive/android_img_huawei.ksy
+++ b/archive/android_img_huawei.ksy
@@ -15,26 +15,34 @@ doc-ref: https://android.googlesource.com/device/huawei/angler/+/673cfb95bf3dcca
 seq:
   - id: img_header
     type: header
-  - id: img_header_entries
-    type: image_header_entry
-    repeat: expr
-    repeat-expr: img_header.image_header_size/80
+  - id: entries
+    type: entries
+    size: img_header.image_header_size
 types:
   header:
      seq:
         - id: magic
           contents: [0x3c, 0xd6, 0x1a, 0xce]
-        - id: major_version
-          type: u2
-        - id: minor_version
-          type: u2
+        - id: version
+          type: version
         - id: image_version
           size: 64
         - id: meta_header_size
           type: u2
         - id: image_header_size
           type: u2
-  image_header_entry:
+  version:
+    seq:
+      - id: major
+        type: u2
+      - id: minor
+        type: u2
+  entries:
+    seq:
+      - id: entries
+        type: entry
+        repeat: eos
+  entry:
     seq:
       - id: name
         type: strz

--- a/archive/android_img_huawei.ksy
+++ b/archive/android_img_huawei.ksy
@@ -1,0 +1,49 @@
+meta:
+  id: android_img_huawei
+  title: Huawei Bootloader packed image format
+  file-extension: img
+  tags:
+    - archive
+    - android
+  license: CC0-1.0
+  endian: le
+doc: |
+  Format of boot files found on certain Android devices from Huawei.
+
+  Example device: Nexus 6P
+doc-ref: https://android.googlesource.com/device/huawei/angler/+/673cfb95bf3dccabae32b382bb17f2b08435b840/releasetools.py
+seq:
+  - id: img_header
+    type: header
+  - id: img_header_entries
+    type: image_header_entry
+    repeat: expr
+    repeat-expr: img_header.image_header_size/80
+types:
+  header:
+     seq:
+        - id: magic
+          contents: [0x3c, 0xd6, 0x1a, 0xce]
+        - id: major_version
+          type: u2
+        - id: minor_version
+          type: u2
+        - id: image_version
+          size: 64
+        - id: meta_header_size
+          type: u2
+        - id: image_header_size
+          type: u2
+  image_header_entry:
+    seq:
+      - id: name
+        type: strz
+        encoding: UTF-8
+        size: 72
+        doc: partition name
+      - id: offset
+        type: u4
+        doc: partition offset from the beginning of the file
+      - id: size
+        type: u4
+        doc: partition size


### PR DESCRIPTION
This commit adds a parser for the Huawei Bootlader packed image format as found on some Android devices made by Huawei. Tested with files found in the OTA image for Nexus 6P.