### PR TITLE
add GRUB2 font description

### DIFF
--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -15,31 +15,31 @@ doc: |
   Bitmap font format for the GRUB 2 bootloader.
 doc-ref: https://grub.gibibit.com/New_font_format
 seq:
-  - id: font_header
+  - id: magic
     contents: ["FILE", 0, 0, 0, 4, "PFF2"]
     size: 12
-  - id: font_sections
-    type: font_section
+  - id: sections
+    type: section
     repeat: until
-    repeat-until: _.section_name == "DATA"
+    repeat-until: _.section_type == "DATA"
     doc: |
       The "DATA" section acts as a terminator. The documentation says:
       "A marker that indicates the remainder of the file is data accessed
       via the character index (CHIX) section. When reading this font file,
       the rest of the file can be ignored when scanning the sections."
 types:
-  font_section:
+  section:
     seq:
-      - id: section_name
+      - id: section_type
         size: 4
         type: str
       - id: len_body
         type: u4
-        doc: Should be set to `0xFFFF_FFFF` for `section_name != "DATA"`
+        doc: Should be set to `0xFFFF_FFFF` for `section_type != "DATA"`
       - id: body
         size: len_body
         type:
-          switch-on: section_name
+          switch-on: section_type
           cases:
             '"NAME"': font_name
             '"FAMI"': font_family_name
@@ -51,7 +51,7 @@ types:
             '"ASCE"': ascent_in_pixels
             '"DESC"': descent_in_pixels
             '"CHIX"': character_index
-        if: section_name != "DATA"
+        if: section_type != "DATA"
   font_name:
     seq:
       - id: name

--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -9,7 +9,7 @@ meta:
   endian: be
 doc: |
   Bitmap font format for the GRUB 2 bootloader.
-doc-ref: http://grub.gibibit.com/New_font_format
+doc-ref: https://grub.gibibit.com/New_font_format
 seq:
   - id: font_header
     contents: ['FILE', 0, 0, 0, 4, 'PFF2']

--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -122,5 +122,15 @@ types:
           - id: bitmap_data
             size: (width * height + 7) / 8 # ceiled integer division
             doc: |
-              Rows of pixels (one bit per pixel), top-down, left-to-right.
-              Padded to be on a byte boundary.
+              A two-dimensional bitmap, one bit per pixel. It is organized as
+              row-major, top-down, left-to-right. The most significant bit of
+              each byte corresponds to the leftmost or uppermost pixel from all
+              bits of the byte. If a bit is set (1, `true`), the pixel is set to
+              the font color, if a bit is clear (0, `false`), the pixel is
+              transparent.
+
+              Rows are **not** padded to byte boundaries (i.e., a
+              single byte may contain bits belonging to multiple rows). The last
+              byte of the bitmap _is_ padded with zero bits at all unused least
+              significant bit positions so that the bitmap ends on a byte
+              boundary.

--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -1,7 +1,11 @@
 meta:
   id: grub2_font
-  title: GRUB2 font
+  title: GRUB 2 font
+  application: GRUB 2
   file-extension: pf2
+  xref:
+    justsolve: PFF2
+    wikidata: Q29650337
   tags:
     - font
   license: CC0-1.0

--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -90,7 +90,7 @@ types:
         type: u2
   character_index:
     seq:
-      - id: entries
+      - id: characters
         type: character
         repeat: eos
     types:
@@ -101,12 +101,12 @@ types:
             doc: Unicode code point
           - id: flags
             type: u1
-          - id: ofs_character
+          - id: ofs_definition
             type: u4
         instances:
-          bitmap:
+          definition:
             io: _root._io
-            pos: ofs_character
+            pos: ofs_definition
             type: character_definition
       character_definition:
         seq:

--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -33,10 +33,10 @@ types:
       - id: section_name
         size: 4
         type: str
-      - id: len_section
+      - id: len_body
         type: u4
       - id: body
-        size: len_section
+        size: len_body
         type:
           switch-on: section_name
           cases:

--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -35,6 +35,7 @@ types:
         type: str
       - id: len_body
         type: u4
+        doc: Should be set to `0xFFFF_FFFF` for `section_name != "DATA"`
       - id: body
         size: len_body
         type:

--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -1,5 +1,5 @@
 meta:
-  id: grub2font
+  id: grub2_font
   title: GRUB2 font
   file-extension: pf2
   tags:

--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -91,8 +91,7 @@ types:
     seq:
       - id: entries
         type: character
-        repeat: expr
-        repeat-expr: _parent.len_section/sizeof<character>
+        repeat: eos
     types:
       character:
         seq:

--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -114,11 +114,11 @@ types:
           - id: height
             type: u2
           - id: x_offset
-            type: u2
+            type: s2
           - id: y_offset
-            type: u2
+            type: s2
           - id: device_width
-            type: u2
+            type: s2
           - id: bitmap_data
             size: (width * height + 7) / 8 # ceiled integer division
             doc: |

--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -41,54 +41,54 @@ types:
         type:
           switch-on: section_type
           cases:
-            '"NAME"': font_name
-            '"FAMI"': font_family_name
-            '"WEIG"': font_weight
-            '"SLAN"': font_slant
-            '"PTSZ"': font_point_size
-            '"MAXW"': maximum_character_width
-            '"MAXH"': maximum_character_height
-            '"ASCE"': ascent_in_pixels
-            '"DESC"': descent_in_pixels
-            '"CHIX"': character_index
+            '"NAME"': name_section
+            '"FAMI"': fami_section
+            '"WEIG"': weig_section
+            '"SLAN"': slan_section
+            '"PTSZ"': ptsz_section
+            '"MAXW"': maxw_section
+            '"MAXH"': maxh_section
+            '"ASCE"': asce_section
+            '"DESC"': desc_section
+            '"CHIX"': chix_section
         if: section_type != "DATA"
-  font_name:
+  name_section:
     seq:
-      - id: name
+      - id: font_name
         type: strz
-  font_family_name:
+  fami_section:
     seq:
-      - id: name
+      - id: font_family_name
         type: strz
-  font_weight:
+  weig_section:
     seq:
-      - id: name
+      - id: font_weight
         type: strz
-  font_slant:
+  slan_section:
     seq:
-      - id: name
+      - id: font_slant
         type: strz
-  font_point_size:
+  ptsz_section:
     seq:
-      - id: point_size
+      - id: font_point_size
         type: u2
-  maximum_character_width:
+  maxw_section:
     seq:
-      - id: width
+      - id: maximum_character_width
         type: u2
-  maximum_character_height:
+  maxh_section:
     seq:
-      - id: height
+      - id: maximum_character_height
         type: u2
-  ascent_in_pixels:
+  asce_section:
     seq:
-      - id: ascent
+      - id: ascent_in_pixels
         type: u2
-  descent_in_pixels:
+  desc_section:
     seq:
-      - id: descent
+      - id: descent_in_pixels
         type: u2
-  character_index:
+  chix_section:
     seq:
       - id: characters
         type: character

--- a/font/grub2_font.ksy
+++ b/font/grub2_font.ksy
@@ -16,7 +16,7 @@ doc: |
 doc-ref: https://grub.gibibit.com/New_font_format
 seq:
   - id: font_header
-    contents: ['FILE', 0, 0, 0, 4, 'PFF2']
+    contents: ["FILE", 0, 0, 0, 4, "PFF2"]
     size: 12
   - id: font_sections
     type: font_section
@@ -29,28 +29,28 @@ seq:
       the rest of the file can be ignored when scanning the sections."
 types:
   font_section:
-     seq:
-       - id: section_name
-         size: 4
-         type: str
-       - id: len_section
-         type: u4
-       - id: body
-         size: len_section
-         type:
-           switch-on: section_name
-           cases:
-             '"NAME"': font_name
-             '"FAMI"': font_family_name
-             '"WEIG"': font_weight
-             '"SLAN"': font_slant
-             '"PTSZ"': font_point_size
-             '"MAXW"': maximum_character_width
-             '"MAXH"': maximum_character_height
-             '"ASCE"': ascent_in_pixels
-             '"DESC"': descent_in_pixels
-             '"CHIX"': character_index
-         if: section_name != "DATA"
+    seq:
+      - id: section_name
+        size: 4
+        type: str
+      - id: len_section
+        type: u4
+      - id: body
+        size: len_section
+        type:
+          switch-on: section_name
+          cases:
+            '"NAME"': font_name
+            '"FAMI"': font_family_name
+            '"WEIG"': font_weight
+            '"SLAN"': font_slant
+            '"PTSZ"': font_point_size
+            '"MAXW"': maximum_character_width
+            '"MAXH"': maximum_character_height
+            '"ASCE"': ascent_in_pixels
+            '"DESC"': descent_in_pixels
+            '"CHIX"': character_index
+        if: section_name != "DATA"
   font_name:
     seq:
       - id: name

--- a/font/grub2font.ksy
+++ b/font/grub2font.ksy
@@ -5,6 +5,7 @@ meta:
   tags:
     - font
   license: CC0-1.0
+  encoding: ASCII
   endian: be
 doc: |
   Bitmap font format for the GRUB 2 bootloader.
@@ -28,11 +29,10 @@ types:
        - id: section_name
          size: 4
          type: str
-         encoding: ASCII
-       - id: section_length
+       - id: len_section
          type: u4
        - id: body
-         size: section_length
+         size: len_section
          type:
            switch-on: section_name
            cases:
@@ -51,22 +51,18 @@ types:
     seq:
       - id: name
         type: strz
-        encoding: ASCII
   font_family_name:
     seq:
       - id: name
         type: strz
-        encoding: ASCII
   font_weight:
     seq:
       - id: name
         type: strz
-        encoding: ASCII
   font_slant:
     seq:
       - id: name
         type: strz
-        encoding: ASCII
   font_point_size:
     seq:
       - id: point_size
@@ -92,7 +88,7 @@ types:
       - id: entries
         type: character
         repeat: expr
-        repeat-expr: _parent.section_length/sizeof<character>
+        repeat-expr: _parent.len_section/sizeof<character>
     types:
       character:
         seq:
@@ -101,12 +97,12 @@ types:
             doc: Unicode code point
           - id: flags
             type: u1
-          - id: offset
+          - id: ofs_character
             type: u4
         instances:
           bitmap:
             io: _root._io
-            pos: offset
+            pos: ofs_character
             type: character_definition
       character_definition:
         seq:

--- a/font/grub2font.ksy
+++ b/font/grub2font.ksy
@@ -17,6 +17,11 @@ seq:
     type: font_section
     repeat: until
     repeat-until: _.section_name == "DATA"
+    doc: |
+      The "DATA" section acts as a terminator. The documentation says:
+      "A marker that indicates the remainder of the file is data accessed
+      via the character index (CHIX) section. When reading this font file,
+      the rest of the file can be ignored when scanning the sections."
 types:
   font_section:
      seq:
@@ -84,12 +89,12 @@ types:
         type: u2
   character_index:
     seq:
-      - id: character_entries
-        type: character_entry
+      - id: entries
+        type: character
         repeat: expr
-        repeat-expr: _parent.section_length/9
+        repeat-expr: _parent.section_length/sizeof<character>
     types:
-      character_entry:
+      character:
         seq:
           - id: code_point
             type: u4

--- a/font/grub2font.ksy
+++ b/font/grub2font.ksy
@@ -103,3 +103,22 @@ types:
             type: u1
           - id: offset
             type: u4
+        instances:
+          bitmap:
+            io: _root._io
+            pos: offset
+            type: character_definition
+      character_definition:
+        seq:
+          - id: width
+            type: u2
+          - id: height
+            type: u2
+          - id: x_offset
+            type: u2
+          - id: y_offset
+            type: u2
+          - id: device_width
+            type: u2
+          - id: bitmap_data
+            size: (width * height + 7) / 8

--- a/font/grub2font.ksy
+++ b/font/grub2font.ksy
@@ -1,0 +1,100 @@
+meta:
+  id: grub2font
+  title: GRUB2 font
+  file-extension: pf2
+  tags:
+    - font
+  license: CC0-1.0
+  endian: be
+doc: |
+  Bitmap font format for the GRUB 2 bootloader.
+doc-ref: http://grub.gibibit.com/New_font_format
+seq:
+  - id: font_header
+    contents: ['FILE', 0, 0, 0, 4, 'PFF2']
+    size: 12
+  - id: font_sections
+    type: font_section
+    repeat: until
+    repeat-until: _.section_name == "DATA"
+types:
+  font_section:
+     seq:
+       - id: section_name
+         size: 4
+         type: str
+         encoding: ASCII
+       - id: section_length
+         type: u4
+       - id: body
+         size: section_length
+         type:
+           switch-on: section_name
+           cases:
+             '"NAME"': font_name
+             '"FAMI"': font_family_name
+             '"WEIG"': font_weight
+             '"SLAN"': font_slant
+             '"PTSZ"': font_point_size
+             '"MAXW"': maximum_character_width
+             '"MAXH"': maximum_character_height
+             '"ASCE"': ascent_in_pixels
+             '"DESC"': descent_in_pixels
+             '"CHIX"': character_index
+         if: section_name != "DATA"
+  font_name:
+    seq:
+      - id: name
+        type: strz
+        encoding: ASCII
+  font_family_name:
+    seq:
+      - id: name
+        type: strz
+        encoding: ASCII
+  font_weight:
+    seq:
+      - id: name
+        type: strz
+        encoding: ASCII
+  font_slant:
+    seq:
+      - id: name
+        type: strz
+        encoding: ASCII
+  font_point_size:
+    seq:
+      - id: point_size
+        type: u2
+  maximum_character_width:
+    seq:
+      - id: width
+        type: u2
+  maximum_character_height:
+    seq:
+      - id: height
+        type: u2
+  ascent_in_pixels:
+    seq:
+      - id: ascent
+        type: u2
+  descent_in_pixels:
+    seq:
+      - id: descent
+        type: u2
+  character_index:
+    seq:
+      - id: character_entries
+        type: character_entry
+        repeat: expr
+        repeat-expr: _parent.section_length/9
+    types:
+      character_entry:
+        seq:
+          - id: code_point
+            type: u4
+            doc: Unicode code point
+          - id: flags
+            type: u1
+          - id: offset
+            type: u4

--- a/font/grub2font.ksy
+++ b/font/grub2font.ksy
@@ -121,4 +121,7 @@ types:
           - id: device_width
             type: u2
           - id: bitmap_data
-            size: (width * height + 7) / 8
+            size: (width * height + 7) / 8 # ceiled integer division
+            doc: |
+              Rows of pixels (one bit per pixel), top-down, left-to-right.
+              Padded to be on a byte boundary.


### PR DESCRIPTION
This description adds support for the GRUB2 font file format. This does not yet process the character definitions itself.