### PR TITLE
wav: fix spelling mistake, process more chunks

### DIFF
--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -137,6 +137,7 @@ types:
         type: strz
 
   bext_chunk_type:
+    doc-ref: https://en.wikipedia.org/wiki/Broadcast_Wave_Format
     seq:
       - id: description
         size: 256
@@ -171,22 +172,21 @@ types:
         type: u2
       - id: max_short_term_loudness
         type: u2
-    doc-ref: https://en.wikipedia.org/wiki/Broadcast_Wave_Format
 
   axml_chunk_type:
+    doc-ref: https://tech.ebu.ch/docs/tech/tech3285s5.pdf
     seq:
       - id: body
         type: str
         size-eos: true
         encoding: UTF-8
-    doc-ref: https://tech.ebu.ch/docs/tech/tech3285s5.pdf
 
   ixml_chunk_type:
+    doc-ref: https://en.wikipedia.org/wiki/IXML
     seq:
       - id: body
         type: strz
         encoding: UTF-8
-    doc-ref: https://en.wikipedia.org/wiki/IXML
 
   cue_chunk_type:
     seq:
@@ -346,13 +346,13 @@ types:
         doc: chunk containing XMP data
         doc-ref: https://wwwimages2.adobe.com/content/dam/acom/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2016-08/XMPSpecificationPart3.pdf
   afsp_chunk_type:
+    doc-ref: http://www-mmsp.ece.mcgill.ca/Documents/Downloads/AFsp/
     seq:
       - id: afspid
         contents: "AFsp"
       - id: text
         type: strz
         encoding: UTF-8
-    doc-ref: http://www-mmsp.ece.mcgill.ca/Documents/Downloads/AFsp/
 
 enums:
   w_format_tag_type:

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -219,9 +219,9 @@ types:
 
   fact_chunk_type:
     seq:
-      - id: sample_length
+      - id: num_samples_per_channel
+        -orig-id: dwSampleLength
         type: u4
-        doc: Number of samples per channel
         doc-ref: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
 
   format_chunk_type:

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -2,8 +2,8 @@ meta:
   id: wav
   title: Microsoft WAVE audio file
   file-extension:
-    - bwf
     - wav
+    - bwf
   xref:
     justsolve: WAV
     loc:

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -638,10 +638,10 @@ enums:
     0x20336469: id3
     0x4b414550: peak
     0x584d505f: pmx
-    0x4c4d5869: ixml
     # BWF chunks
     0x74786562: bext
     0x6c6d7861: axml
+    0x4c4d5869: ixml
     # Audio definition model
     0x616e6863: chna
     # AFsp

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -5,29 +5,42 @@ meta:
     - wav
     - bwf
   xref:
-    justsolve: WAV
+    justsolve:
+      - WAV
+      - BWF
     loc:
       - fdd000001 # WAV
-      - fdd000003 # BWF
-      - fdd000356 # BWF
-      - fdd000357 # BWF
-      - fdd000359 # BWF
+      - fdd000002 # WAV PCM
+      - fdd000356 # BWF v1
+      - fdd000003 # BWF v1 PCM
+      - fdd000357 # BWF v2
+      - fdd000359 # BWF v2 PCM
     mime:
       - audio/vnd.wave
       - audio/wav
       - audio/wave
       - audio/x-wav
     pronom:
-      - fmt/1 # BWF
-      - fmt/2 # BWF
       - fmt/6 # WAV
-      - fmt/527 # BWF
-      - fmt/703 # BWF
-      - fmt/704 # BWF
-      - fmt/705 # BWF
-      - fmt/709 # BWF
-      - fmt/710 # BWF
-      - fmt/711 # BWF
+      - fmt/141 # WAV PCM
+      - fmt/142 # WAV non-PCM but not extensible
+      - fmt/143 # WAV extensible
+
+      # see <http://fileformats.archiveteam.org/wiki/BWF>
+      - fmt/1 # BWF v0
+      - fmt/703 # BWF v0 PCM
+      - fmt/706 # BWF v0 MPEG
+      - fmt/709 # BWF v0 extensible
+
+      - fmt/2 # BWF v1
+      - fmt/704 # BWF v1 PCM
+      - fmt/707 # BWF v1 MPEG
+      - fmt/710 # BWF v1 extensible
+
+      - fmt/527 # BWF v2
+      - fmt/705 # BWF v2 PCM
+      - fmt/708 # BWF v2 MPEG
+      - fmt/711 # BWF v2 extensible
     rfc: 2361
     wikidata:
       - Q217570 # WAV

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -175,7 +175,7 @@ types:
   axml_chunk_type:
     doc-ref: https://tech.ebu.ch/docs/tech/tech3285s5.pdf
     seq:
-      - id: body
+      - id: data
         size-eos: true
         type: str
         encoding: UTF-8
@@ -183,8 +183,9 @@ types:
   ixml_chunk_type:
     doc-ref: https://en.wikipedia.org/wiki/IXML
     seq:
-      - id: body
-        type: strz
+      - id: data
+        size-eos: true
+        type: str
         encoding: UTF-8
 
   cue_chunk_type:
@@ -343,8 +344,9 @@ types:
         size-eos: true
         type: str
         encoding: UTF-8
-        doc: chunk containing XMP data
+        doc: XMP data
         doc-ref: https://wwwimages2.adobe.com/content/dam/acom/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2016-08/XMPSpecificationPart3.pdf
+
   afsp_chunk_type:
     doc-ref: http://www-mmsp.ece.mcgill.ca/Documents/Downloads/AFsp/
     seq:

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -352,7 +352,9 @@ types:
         contents: "AFsp"
       - id: info_records
         type: strz
-        encoding: UTF-8
+        # The AFsp package uses C strings, so the encoding isn't strictly
+        # defined. Therefore, it seems reasonable to assume ASCII.
+        encoding: ASCII
         repeat: eos
         doc-ref:
           - http://www-mmsp.ece.mcgill.ca/Documents/Software/Packages/AFsp/libtsp/AFsetInfo.html

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -57,7 +57,6 @@ doc: |
 doc-ref:
   - http://soundfile.sapp.org/doc/WaveFormat/
   - https://web.archive.org/web/20101031101749/http://www.ebu.ch/fr/technical/publications/userguides/bwf_user_guide.php
-  - https://www.itu.int/rec/R-REC-BS.2076-2-201910-I/en
 seq:
   - id: chunk
     type: 'riff::chunk'
@@ -643,6 +642,8 @@ enums:
     0x6c6d7861: axml
     0x4c4d5869: ixml
     # Audio definition model
-    0x616e6863: chna
+    0x616e6863:
+      id: chna
+      doc-ref: https://www.itu.int/rec/R-REC-BS.2076-2-201910-I/en
     # AFsp
     0x70736661: afsp

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -69,6 +69,7 @@ doc: |
   (jbyrd@giganticsoftware.com), and it is likely to contain bugs.
 doc-ref:
   - http://soundfile.sapp.org/doc/WaveFormat/
+  - http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
   - https://web.archive.org/web/20101031101749/http://www.ebu.ch/fr/technical/publications/userguides/bwf_user_guide.php
 seq:
   - id: chunk
@@ -231,8 +232,10 @@ types:
         size-eos: true
 
   fact_chunk_type:
-    doc: required for all non-PCM formats (other than `w_format_tag_type::pcm`)
-    doc-ref: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
+    doc: |
+      required for all non-PCM formats
+      (`w_format_tag != w_format_tag_type::pcm` or `not is_basic_pcm` in
+      `format_chunk_type` context)
     seq:
       - id: num_samples_per_channel
         -orig-id: dwSampleLength

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -77,6 +77,7 @@ types:
             'fourcc::data': data_chunk_type
             'fourcc::list': list_chunk_type
             'fourcc::pmx': pmx_chunk_type
+            'fourcc::fact': fact_chunk_type
 
   list_chunk_type:
     seq:
@@ -169,6 +170,13 @@ types:
     seq:
       - id: data
         size-eos: true
+
+  fact_chunk_type:
+    seq:
+      - id: sample_length
+        type: u4
+        doc: Number of samples per channel
+        doc-ref: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
 
   format_chunk_type:
     seq:

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -565,3 +565,5 @@ enums:
     0x6e676572: regn
     0x20336469: id3
     0x4b414550: peak
+    0x584d505f: pmx
+    0x74636166: fact

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -297,6 +297,8 @@ types:
         size-eos: true
         type: str
         encoding: UTF-8
+        doc: chunk containing XMP data
+        doc-ref: https://wwwimages2.adobe.com/content/dam/acom/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2016-08/XMPSpecificationPart3.pdf
 enums:
   w_format_tag_type:
     0x0000: unknown

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -76,6 +76,7 @@ types:
             'fourcc::cue': cue_chunk_type
             'fourcc::data': data_chunk_type
             'fourcc::list': list_chunk_type
+            'fourcc::pmx': pmx_chunk_type
 
   list_chunk_type:
     seq:
@@ -282,6 +283,12 @@ types:
       - id: sample
         type: u2
 
+  pmx_chunk_type:
+    seq:
+      - id: data
+        size-eos: true
+        type: str
+        encoding: UTF-8
 enums:
   w_format_tag_type:
     0x0000: unknown

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -544,7 +544,7 @@ enums:
     0xa120: vocord_g723_1
     0xa121: vocord_lbc
     0xa122: nice_g728
-    0xa123: frace_telecom_g729
+    0xa123: france_telecom_g729
     0xa124: codian
     0xf1ac: flac
     0xfffe: extensible
@@ -563,3 +563,5 @@ enums:
     0x64696d75: umid
     0x666e696d: minf
     0x6e676572: regn
+    0x20336469: id3
+    0x4b414550: peak

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -217,11 +217,12 @@ types:
         size-eos: true
 
   fact_chunk_type:
+    doc: required for all non-PCM formats (other than `w_format_tag_type::pcm`)
+    doc-ref: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
     seq:
       - id: num_samples_per_channel
         -orig-id: dwSampleLength
         type: u4
-        doc-ref: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
 
   format_chunk_type:
     seq:

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -358,6 +358,10 @@ types:
         # defined. Therefore, it seems reasonable to assume ASCII.
         encoding: ASCII
         repeat: eos
+        doc: |
+          An array of AFsp information records, in the `<field_name>: <value>`
+          format (e.g. "`program: CopyAudio`"). The list of existing information
+          record types are available in the `doc-ref` links.
         doc-ref:
           - http://www-mmsp.ece.mcgill.ca/Documents/Software/Packages/AFsp/libtsp/AFsetInfo.html
           - http://www-mmsp.ece.mcgill.ca/Documents/Software/Packages/AFsp/libtsp/AFprintInfoRecs.html

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -349,9 +349,13 @@ types:
     seq:
       - id: magic
         contents: "AFsp"
-      - id: text
+      - id: info_records
         type: strz
         encoding: UTF-8
+        repeat: eos
+        doc-ref:
+          - http://www-mmsp.ece.mcgill.ca/Documents/Software/Packages/AFsp/libtsp/AFsetInfo.html
+          - http://www-mmsp.ece.mcgill.ca/Documents/Software/Packages/AFsp/libtsp/AFprintInfoRecs.html
 
 enums:
   w_format_tag_type:

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -348,7 +348,7 @@ types:
   afsp_chunk_type:
     doc-ref: http://www-mmsp.ece.mcgill.ca/Documents/Downloads/AFsp/
     seq:
-      - id: afspid
+      - id: magic
         contents: "AFsp"
       - id: text
         type: strz

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -176,8 +176,8 @@ types:
     doc-ref: https://tech.ebu.ch/docs/tech/tech3285s5.pdf
     seq:
       - id: body
-        type: str
         size-eos: true
+        type: str
         encoding: UTF-8
 
   ixml_chunk_type:

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -650,9 +650,10 @@ enums:
     0x74786562: bext
     0x6c6d7861: axml
     0x4c4d5869: ixml
-    # Audio definition model
     0x616e6863:
       id: chna
+      doc: Audio definition model
       doc-ref: https://www.itu.int/rec/R-REC-BS.2076-2-201910-I/en
-    # AFsp
-    0x70736661: afsp
+    0x70736661:
+      id: afsp
+      doc: AFsp metadata

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -47,7 +47,7 @@ doc: |
   a "fmt " chunk specifying the data format and a "data" chunk containing
   the actual sample data, although other chunks exist and are used.
 
-  An extension of the file format is the Broadcast Wave Format for radio
+  An extension of the file format is the Broadcast Wave Format (BWF) for radio
   broadcasts. Sample files can be found at:
 
   https://www.bbc.co.uk/rd/publications/saqas

--- a/media/wav.ksy
+++ b/media/wav.ksy
@@ -1,18 +1,37 @@
 meta:
   id: wav
   title: Microsoft WAVE audio file
-  file-extension: wav
+  file-extension:
+    - bwf
+    - wav
   xref:
     justsolve: WAV
-    loc: fdd000001
+    loc:
+      - fdd000001 # WAV
+      - fdd000003 # BWF
+      - fdd000356 # BWF
+      - fdd000357 # BWF
+      - fdd000359 # BWF
     mime:
       - audio/vnd.wave
       - audio/wav
       - audio/wave
       - audio/x-wav
-    pronom: fmt/6
+    pronom:
+      - fmt/1 # BWF
+      - fmt/2 # BWF
+      - fmt/6 # WAV
+      - fmt/527 # BWF
+      - fmt/703 # BWF
+      - fmt/704 # BWF
+      - fmt/705 # BWF
+      - fmt/709 # BWF
+      - fmt/710 # BWF
+      - fmt/711 # BWF
     rfc: 2361
-    wikidata: Q217570
+    wikidata:
+      - Q217570 # WAV
+      - Q922446 # BWF
   tags:
     - windows
   license: BSD-3-Clause-Attribution
@@ -26,11 +45,19 @@ doc: |
   followed by a sequence of data chunks. A WAVE file is often just a RIFF
   file with a single "WAVE" chunk which consists of two sub-chunks --
   a "fmt " chunk specifying the data format and a "data" chunk containing
-  the actual sample data.
+  the actual sample data, although other chunks exist and are used.
+
+  An extension of the file format is the Broadcast Wave Format for radio
+  broadcasts. Sample files can be found at:
+
+  https://www.bbc.co.uk/rd/publications/saqas
 
   This Kaitai implementation was written by John Byrd of Gigantic Software
   (jbyrd@giganticsoftware.com), and it is likely to contain bugs.
-doc-ref: http://soundfile.sapp.org/doc/WaveFormat/
+doc-ref:
+  - http://soundfile.sapp.org/doc/WaveFormat/
+  - https://web.archive.org/web/20101031101749/http://www.ebu.ch/fr/technical/publications/userguides/bwf_user_guide.php
+  - https://www.itu.int/rec/R-REC-BS.2076-2-201910-I/en
 seq:
   - id: chunk
     type: 'riff::chunk'
@@ -72,12 +99,15 @@ types:
           switch-on: chunk_id
           cases:
             'fourcc::fmt': format_chunk_type
-            'fourcc::bext': bext_chunk_type
             'fourcc::cue': cue_chunk_type
             'fourcc::data': data_chunk_type
             'fourcc::list': list_chunk_type
-            'fourcc::pmx': pmx_chunk_type
             'fourcc::fact': fact_chunk_type
+            'fourcc::pmx': pmx_chunk_type
+            'fourcc::ixml': ixml_chunk_type
+            'fourcc::bext': bext_chunk_type
+            'fourcc::axml': axml_chunk_type
+            'fourcc::afsp': afsp_chunk_type
 
   list_chunk_type:
     seq:
@@ -141,6 +171,22 @@ types:
         type: u2
       - id: max_short_term_loudness
         type: u2
+    doc-ref: https://en.wikipedia.org/wiki/Broadcast_Wave_Format
+
+  axml_chunk_type:
+    seq:
+      - id: body
+        type: str
+        size-eos: true
+        encoding: UTF-8
+    doc-ref: https://tech.ebu.ch/docs/tech/tech3285s5.pdf
+
+  ixml_chunk_type:
+    seq:
+      - id: body
+        type: strz
+        encoding: UTF-8
+    doc-ref: https://en.wikipedia.org/wiki/IXML
 
   cue_chunk_type:
     seq:
@@ -299,6 +345,15 @@ types:
         encoding: UTF-8
         doc: chunk containing XMP data
         doc-ref: https://wwwimages2.adobe.com/content/dam/acom/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2016-08/XMPSpecificationPart3.pdf
+  afsp_chunk_type:
+    seq:
+      - id: afspid
+        contents: "AFsp"
+      - id: text
+        type: strz
+        encoding: UTF-8
+    doc-ref: http://www-mmsp.ece.mcgill.ca/Documents/Downloads/AFsp/
+
 enums:
   w_format_tag_type:
     0x0000: unknown
@@ -573,8 +628,8 @@ enums:
     0x45564157: wave
     0x5453494c: list
     0x4f464e49: info
+    0x74636166: fact
     0x20746d66: fmt
-    0x74786562: bext
     0x20657563: cue
     0x61746164: data
     0x64696d75: umid
@@ -583,4 +638,11 @@ enums:
     0x20336469: id3
     0x4b414550: peak
     0x584d505f: pmx
-    0x74636166: fact
+    0x4c4d5869: ixml
+    # BWF chunks
+    0x74786562: bext
+    0x6c6d7861: axml
+    # Audio definition model
+    0x616e6863: chna
+    # AFsp
+    0x70736661: afsp


### PR DESCRIPTION
This PR fixes a simple spelling mistakes and adds chunk names that are not in the standard spec, namely ID3 and PEAK. The data of these chunks is not yet processed any further.

Test files for ID3: https://github.com/alexa/alexa-auto-sdk/tree/3.1/samples/cpp/assets/inputs
Test files for PEAK: https://github.com/scipy/scipy/tree/master/scipy/io/tests/data