### PR TITLE
add a specification for the bootloader used on several ASUS Android devices

### DIFF
--- a/archive/android_asus_bootldr.ksy
+++ b/archive/android_asus_bootldr.ksy
@@ -40,13 +40,13 @@ types:
     -webide-representation: '{file_name}'
     seq:
       - id: magic
+        size: 8
         type: str
         valid:
           any-of:
             - '"IFWI!!!!"'
             - '"DROIDBT!"'
             - '"SPLASHS!"'
-        size: 8
       - id: len_body
         type: u4
       - id: flags

--- a/archive/android_asus_bootldr.ksy
+++ b/archive/android_asus_bootldr.ksy
@@ -39,7 +39,7 @@ types:
   image:
     -webide-representation: '{file_name}'
     seq:
-      - id: magic
+      - id: chunk_id
         size: 8
         type: str
         valid:
@@ -64,7 +64,7 @@ types:
     instances:
       file_name:
         value: |
-          magic == "IFWI!!!!" ? "ifwi.bin" :
-          magic == "DROIDBT!" ? "droidboot.img" :
-          magic == "SPLASHS!" ? "splashscreen.img" :
+          chunk_id == "IFWI!!!!" ? "ifwi.bin" :
+          chunk_id == "DROIDBT!" ? "droidboot.img" :
+          chunk_id == "SPLASHS!" ? "splashscreen.img" :
           ""

--- a/archive/android_asus_bootldr.ksy
+++ b/archive/android_asus_bootldr.ksy
@@ -12,6 +12,9 @@ doc: |
   A bootloader image which only seems to have been used on a few ASUS
   devices. The encoding is ASCII, because the `releasetools.py` script
   is written using Python 2, where the default encoding is ASCII.
+
+  A test file can be found in the firmware files for the "fugu" device,
+  which can be downloaded from <https://developers.google.com/android/images>
 doc-ref: https://android.googlesource.com/device/asus/fugu/+/android-8.1.0_r5/releasetools.py
 seq:
   - id: magic

--- a/archive/android_asus_bootldr.ksy
+++ b/archive/android_asus_bootldr.ksy
@@ -1,0 +1,51 @@
+meta:
+  id: android_asus_bootldr
+  title: ASUS Fugu bootloader.img format (version 2 and later)
+  file-extension: img
+  tags:
+    - archive
+    - android
+  license: CC0-1.0
+  encoding: ASCII
+  endian: le
+doc: |
+  A bootloader image which only seems to have been used on a few ASUS
+  devices. The encoding is ASCII, because the `releasetools.py` script
+  is written using Python 2, where the default encoding is ASCII.
+doc-ref: https://android.googlesource.com/device/asus/fugu/+/android-8.1.0_r5/releasetools.py
+seq:
+  - id: magic
+    contents: BOOTLDR!
+  - id: revision
+    type: u2
+    valid:
+      min: 2
+  - id: reserved1
+    type: u2
+  - id: reserved2
+    type: u4
+  - id: images
+    type: image
+    repeat: expr
+    repeat-expr: 3
+    doc: |
+      Only three images are included: `ifwi.bin`, `droidboot.img`
+      and `splashscreen.img`
+types:
+  image:
+    seq:
+      - id: magic
+        type: str
+        size: 8
+      - id: len_image
+        type: u4
+      - id: flags
+        type: u1
+      - id: reserved1
+        type: u1
+      - id: reserved2
+        type: u1
+      - id: reserved3
+        type: u1
+      - id: body
+        size: len_image

--- a/archive/android_asus_bootldr.ksy
+++ b/archive/android_asus_bootldr.ksy
@@ -40,7 +40,7 @@ types:
       - id: magic
         type: str
         size: 8
-      - id: len_image
+      - id: len_body
         type: u4
       - id: flags
         type: u1
@@ -51,4 +51,4 @@ types:
       - id: reserved3
         type: u1
       - id: body
-        size: len_image
+        size: len_body

--- a/archive/android_asus_bootldr.ksy
+++ b/archive/android_asus_bootldr.ksy
@@ -6,6 +6,7 @@ meta:
     - archive
     - android
   license: CC0-1.0
+  ks-version: 0.9
   encoding: ASCII
   endian: le
 doc: |
@@ -39,11 +40,18 @@ types:
     seq:
       - id: magic
         type: str
+        valid:
+          any-of:
+            - '"IFWI!!!!"' # ifwi.bin
+            - '"DROIDBT!"' # droidboot.img
+            - '"SPLASHS!"' # splashscreen.img
         size: 8
       - id: len_body
         type: u4
       - id: flags
         type: u1
+        valid:
+          expr: _ & 1 != 0
       - id: reserved1
         type: u1
       - id: reserved2

--- a/archive/android_asus_bootldr.ksy
+++ b/archive/android_asus_bootldr.ksy
@@ -37,14 +37,15 @@ seq:
       and `splashscreen.img`
 types:
   image:
+    -webide-representation: '{file_name}'
     seq:
       - id: magic
         type: str
         valid:
           any-of:
-            - '"IFWI!!!!"' # ifwi.bin
-            - '"DROIDBT!"' # droidboot.img
-            - '"SPLASHS!"' # splashscreen.img
+            - '"IFWI!!!!"'
+            - '"DROIDBT!"'
+            - '"SPLASHS!"'
         size: 8
       - id: len_body
         type: u4
@@ -60,3 +61,10 @@ types:
         type: u1
       - id: body
         size: len_body
+    instances:
+      file_name:
+        value: |
+          magic == "IFWI!!!!" ? "ifwi.bin" :
+          magic == "DROIDBT!" ? "droidboot.img" :
+          magic == "SPLASHS!" ? "splashscreen.img" :
+          ""


### PR DESCRIPTION
This is a specification for the bootloader used on several ASUS Android devices. The magic is the same as some other Android bootloaders. I have only implemented support for version 2 and later, as I couldn't quickly find test files that use version 1 (and I am not even sure if any of those files were even publicly released).