### PR TITLE
add XAR header format

### DIFF
--- a/archive/xar.ksy
+++ b/archive/xar.ksy
@@ -27,18 +27,31 @@ doc: |
   supports additional checksums, but doesn't have checksum_name.
 doc-ref: https://github.com/mackyle/xar/wiki/xarformat
 seq:
-  - id: magic
-    contents: 'xar!'
-  - id: len_header
-    type: u2
+  - id: header_prefix
+    type: file_header_prefix
+    doc: internal; access `_root.header` instead
   - id: header
-    type:
-      switch-on: len_header
-      cases:
-        28: apple_header
-        _: regular_header
+    size: header_prefix.len_header - header_prefix._sizeof
+    type: file_header
+  - id: toc
+    size: header.len_toc_compressed
+    type: toc_type
+    process: zlib
+    doc: zlib compressed XML further describing the content of the archive
+instances:
+  checksum_algorithm_other:
+    -orig-id: XAR_CKSUM_OTHER
+    value: 3
+    doc-ref: https://github.com/mackyle/xar/blob/66d451d/xar/include/xar.h.in#L85
 types:
-  regular_header:
+  file_header_prefix:
+    seq:
+      - id: magic
+        contents: 'xar!'
+      - id: len_header
+        type: u2
+        doc: internal; access `_root.header.len_header` instead
+  file_header:
     seq:
       - id: version
         type: u2
@@ -48,40 +61,61 @@ types:
         type: u8
       - id: toc_length_uncompressed
         type: u8
-      - id: checksum_algorithm
+      - id: checksum_algorithm_int
         type: u4
-        enum: checksum_algorithms
-      - id: checksum_name
+        doc: internal; access `checksum_algorithm_name` instead
+      - id: checksum_alg_name
+        size-eos: true
         type: strz
-        size: 36
-        if: checksum_algorithm == checksum_algorithms::other
-      - id: toc
-        size: len_toc_compressed
-        process: zlib
-        doc: zlib compressed XML further describing the content of the archive
-  apple_header:
+        valid:
+          expr: _ != "" and _ != "none"
+        if: has_checksum_alg_name
+        doc: internal; access `checksum_algorithm_name` instead
+    instances:
+      checksum_algorithm_name:
+        value: |
+          has_checksum_alg_name ? checksum_alg_name
+          : checksum_algorithm_int == checksum_algorithms_apple::none.to_i ? "none"
+          : checksum_algorithm_int == checksum_algorithms_apple::sha1.to_i ? "sha1"
+          : checksum_algorithm_int == checksum_algorithms_apple::md5.to_i ? "md5"
+          : checksum_algorithm_int == checksum_algorithms_apple::sha256.to_i ? "sha256"
+          : checksum_algorithm_int == checksum_algorithms_apple::sha512.to_i ? "sha512"
+          : ""
+        doc: |
+          If it is not
+
+          * `""` (empty string), indicating an unknown integer value (read
+            `checksum_algorithm_int` for debugging purposes to find out
+            what that value is), or
+          * `"none"`, indicating that the TOC checksum is not provided (in that
+            case, the `<checksum>` property or its `style` attribute should be
+            missing, or the `style` attribute must be set to `"none"`),
+
+          it must exactly match the `style` attribute value of the
+          `<checksum>` property in the root node `<toc>`. See
+          <https://github.com/mackyle/xar/blob/66d451d/xar/lib/archive.c#L345-L371>
+          for reference.
+
+          The `xar` (eXtensible ARchiver) program [uses OpenSSL's function
+          `EVP_get_digestbyname`](
+            https://github.com/mackyle/xar/blob/66d451d/xar/lib/archive.c#L328
+          ) to verify this value (if it's not `""` or `"none"`, of course).
+          So it's reasonable to assume that this can only have one of the values
+          that OpenSSL recognizes.
+      has_checksum_alg_name:
+        value: |
+          checksum_algorithm_int == _root.checksum_algorithm_other
+          and len_header >= 32
+          and len_header % 4 == 0
+      len_header:
+        value: _root.header_prefix.len_header
+  toc_type:
     seq:
-      - id: version
-        type: u2
-        valid: 1
-      - id: len_toc_compressed
-        -orig-id: toc_length_compressed
-        type: u8
-      - id: toc_length_uncompressed
-        type: u8
-      - id: checksum_algorithm
-        type: u4
-        enum: checksum_algorithms_apple
-      - id: toc
-        size: len_toc_compressed
-        process: zlib
-        doc: zlib compressed XML further describing the content of the archive
+      - id: xml_string
+        type: str
+        size-eos: true
 enums:
-  checksum_algorithms:
-    0: none
-    1: sha1
-    2: md5
-    3: other
+  # https://github.com/opensource-apple/cctools/blob/fdb4825/include/xar/xar.h#L63-L67
   checksum_algorithms_apple:
     0: none
     1: sha1

--- a/archive/xar.ksy
+++ b/archive/xar.ksy
@@ -15,16 +15,12 @@ meta:
   encoding: UTF-8
   endian: be
 doc: |
-  From Wikipedia:
+  From [Wikipedia](https://en.wikipedia.org/wiki/Xar_(archiver)):
 
   "XAR (short for eXtensible ARchive format) is an open source file archiver
   and the archiver’s file format. It was created within the OpenDarwin project
   and is used in macOS X 10.5 and up for software installation routines, as
   well as browser extensions in Safari 5.0 and up."
-
-  It should be noted that there is a different version from Apple which uses
-  the same version number as the (unmaintained) version described here and
-  supports additional checksums, but doesn't have `checksum_alg_name`.
 doc-ref: https://github.com/mackyle/xar/wiki/xarformat
 seq:
   - id: header_prefix

--- a/archive/xar.ksy
+++ b/archive/xar.ksy
@@ -22,9 +22,9 @@ doc: |
   and is used in macOS X 10.5 and up for software installation routines, as
   well as browser extensions in Safari 5.0 and up."
 
-  It should be noted that there is a different version from Apple uses the
-  same version number as the (unmaintained) version described here, but that
-  supports additional checksums, but doesn't have checksum_name.
+  It should be noted that there is a different version from Apple which uses
+  the same version number as the (unmaintained) version described here and
+  supports additional checksums, but doesn't have `checksum_alg_name`.
 doc-ref: https://github.com/mackyle/xar/wiki/xarformat
 seq:
   - id: header_prefix

--- a/archive/xar.ksy
+++ b/archive/xar.ksy
@@ -6,6 +6,7 @@ meta:
     - xar
     - xip
   xref:
+    justsolve: Xar_(Extensible_Archive)
     mime: application/x-xar
     pronom: fmt/600
     wikidata: Q1093556

--- a/archive/xar.ksy
+++ b/archive/xar.ksy
@@ -2,8 +2,8 @@ meta:
   id: xar
   title: XAR (eXtensible ARchive)
   file-extension:
-    - pkg
     - xar
+    - pkg
     - xip
   xref:
     justsolve: Xar_(Extensible_Archive)

--- a/archive/xar.ksy
+++ b/archive/xar.ksy
@@ -1,6 +1,6 @@
 meta:
   id: xar
-  title: eXtensible ARchiver
+  title: XAR (eXtensible ARchive)
   file-extension:
     - pkg
     - xar

--- a/archive/xar.ksy
+++ b/archive/xar.ksy
@@ -80,7 +80,7 @@ types:
         doc: |
           If it is not
 
-          * `""` (empty string), indicating an unknown integer value (read
+          * `""` (empty string), indicating an unknown integer value (access
             `checksum_algorithm_int` for debugging purposes to find out
             what that value is), or
           * `"none"`, indicating that the TOC checksum is not provided (in that

--- a/archive/xar.ksy
+++ b/archive/xar.ksy
@@ -115,7 +115,7 @@ types:
         type: str
         size-eos: true
 enums:
-  # https://github.com/opensource-apple/cctools/blob/fdb4825/include/xar/xar.h#L63-L67
+  # https://github.com/apple-opensource/xar/blob/03d10ac/xar/include/xar.h.in#L67-L73
   checksum_algorithms_apple:
     0: none
     1: sha1

--- a/archive/xar.ksy
+++ b/archive/xar.ksy
@@ -1,5 +1,5 @@
 meta:
-  id: xar_header
+  id: xar
   title: eXtensible ARchiver
   file-extension:
     - pkg

--- a/archive/xar_header.ksy
+++ b/archive/xar_header.ksy
@@ -11,7 +11,20 @@ meta:
     wikidata: Q1093556
   license: CC0-1.0
   ks-version: 0.9
+  encoding: UTF-8
   endian: be
+doc: |
+  From Wikipedia:
+
+  "XAR (short for eXtensible ARchive format) is an open source file archiver
+  and the archiver’s file format. It was created within the OpenDarwin project
+  and is used in macOS X 10.5 and up for software installation routines, as
+  well as browser extensions in Safari 5.0 and up."
+
+  It should be noted that there is a different version from Apple uses the
+  same version number as the (unmaintained) version described here, but that
+  supports additional checksums, but doesn't have checksum_name.
+versions
 doc-ref: https://github.com/mackyle/xar/wiki/xarformat
 seq:
   - id: magic
@@ -29,6 +42,10 @@ seq:
   - id: checksum_algorithm
     type: u4
     enum: checksum_algorithms
+  - id: checksum_name
+    type: strz
+    size: 36
+    if: checksum_algorithm == checksum_algorithms::other
   - id: toc
     size: len_toc_compressed
     process: zlib
@@ -38,3 +55,4 @@ enums:
     0: none
     1: sha1
     2: md5
+    3: other

--- a/archive/xar_header.ksy
+++ b/archive/xar_header.ksy
@@ -42,7 +42,7 @@ types:
       - id: version
         type: u2
         valid: 1
-      - id: toc_length_compressed
+      - id: len_toc_compressed
         -orig-id: toc_length_compressed
         type: u8
       - id: toc_length_uncompressed
@@ -63,7 +63,7 @@ types:
       - id: version
         type: u2
         valid: 1
-      - id: toc_length_compressed
+      - id: len_toc_compressed
         -orig-id: toc_length_compressed
         type: u8
       - id: toc_length_uncompressed

--- a/archive/xar_header.ksy
+++ b/archive/xar_header.ksy
@@ -1,0 +1,40 @@
+meta:
+  id: xar_header
+  title: eXtensible ARchiver
+  file-extension:
+    - pkg
+    - xar
+    - xip
+  xref:
+    mime: application/x-xar
+    pronom: fmt/600
+    wikidata: Q1093556
+  license: CC0-1.0
+  ks-version: 0.9
+  endian: be
+doc-ref: https://github.com/mackyle/xar/wiki/xarformat
+seq:
+  - id: magic
+    contents: 'xar!'
+  - id: header_size
+    type: u2
+  - id: version
+    type: u2
+    valid: 1
+  - id: len_toc_compressed
+    -orig-id: toc_length_compressed
+    type: u8
+  - id: toc_length_uncompressed
+    type: u8
+  - id: checksum_algorithm
+    type: u4
+    enum: checksum_algorithms
+  - id: toc
+    size: len_toc_compressed
+    process: zlib
+    doc: zlib compressed XML further describing the content of the archive
+enums:
+  checksum_algorithms:
+    0: none
+    1: sha1
+    2: md5

--- a/archive/xar_header.ksy
+++ b/archive/xar_header.ksy
@@ -24,35 +24,66 @@ doc: |
   It should be noted that there is a different version from Apple uses the
   same version number as the (unmaintained) version described here, but that
   supports additional checksums, but doesn't have checksum_name.
-versions
 doc-ref: https://github.com/mackyle/xar/wiki/xarformat
 seq:
   - id: magic
     contents: 'xar!'
-  - id: header_size
+  - id: len_header
     type: u2
-  - id: version
-    type: u2
-    valid: 1
-  - id: len_toc_compressed
-    -orig-id: toc_length_compressed
-    type: u8
-  - id: toc_length_uncompressed
-    type: u8
-  - id: checksum_algorithm
-    type: u4
-    enum: checksum_algorithms
-  - id: checksum_name
-    type: strz
-    size: 36
-    if: checksum_algorithm == checksum_algorithms::other
-  - id: toc
-    size: len_toc_compressed
-    process: zlib
-    doc: zlib compressed XML further describing the content of the archive
+  - id: header
+    type:
+      switch-on: len_header
+      cases:
+        28: apple_header
+        _: regular_header
+types:
+  regular_header:
+    seq:
+      - id: version
+        type: u2
+        valid: 1
+      - id: toc_length_compressed
+        -orig-id: toc_length_compressed
+        type: u8
+      - id: toc_length_uncompressed
+        type: u8
+      - id: checksum_algorithm
+        type: u4
+        enum: checksum_algorithms
+      - id: checksum_name
+        type: strz
+        size: 36
+        if: checksum_algorithm == checksum_algorithms::other
+      - id: toc
+        size: len_toc_compressed
+        process: zlib
+        doc: zlib compressed XML further describing the content of the archive
+  apple_header:
+    seq:
+      - id: version
+        type: u2
+        valid: 1
+      - id: toc_length_compressed
+        -orig-id: toc_length_compressed
+        type: u8
+      - id: toc_length_uncompressed
+        type: u8
+      - id: checksum_algorithm
+        type: u4
+        enum: checksum_algorithms_apple
+      - id: toc
+        size: len_toc_compressed
+        process: zlib
+        doc: zlib compressed XML further describing the content of the archive
 enums:
   checksum_algorithms:
     0: none
     1: sha1
     2: md5
     3: other
+  checksum_algorithms_apple:
+    0: none
+    1: sha1
+    2: md5
+    3: sha256
+    4: sha512


### PR DESCRIPTION
The XAR format is an archive that consists of a header, a zlib compressed XML document and then the payload. The structure of the payload (the files, etc.) is described in the XML file. Because Kaitai Struct does not have a built in XML parser this parser is limited to just the header.