### PR TITLE
ruby_marshal: add support for object link '@'

### DIFF
--- a/serialization/ruby_marshal.ksy
+++ b/serialization/ruby_marshal.ksy
@@ -52,6 +52,7 @@ types:
             'codes::ruby_struct': ruby_struct
             'codes::ruby_symbol': ruby_symbol
             'codes::ruby_symbol_link': packed_int
+            'codes::ruby_object_link': packed_int
   packed_int:
     doc: |
       Ruby uses sophisticated system to pack integers: first `code`
@@ -198,6 +199,7 @@ enums:
     0x30: const_nil
     0x3a: ruby_symbol
     0x3b: ruby_symbol_link
+    0x40: ruby_object_link
     0x46: const_false
     0x49: instance_var
     0x53: ruby_struct


### PR DESCRIPTION
See https://docs.ruby-lang.org/en/2.4.0/marshal_rdoc.html#label-Object+References