### PR TITLE
Fix edid.ksy

### DIFF
--- a/hardware/edid.ksy
+++ b/hardware/edid.ksy
@@ -54,6 +54,7 @@ seq:
       DMT (Discrete Monitor Timings) modes.
     doc-ref: Standard, section 3.8
   - id: std_timings
+    size: 2
     type: std_timing
     doc: |
       Array of descriptions of so called "standard timings", which are
@@ -237,13 +238,18 @@ types:
           Refresh rate in Hz, written in modified form: `refresh_rate
           - 60`. This yields an effective range of 60..123 Hz.
     instances:
+      bytes_lookahead:
+        pos: 0
+        size: 2
+      is_used:
+        value: bytes_lookahead != [0x01, 0x01]
       horiz_active_pixels:
-        if: not (horiz_active_pixels_mod == 0x01 and aspect_ratio == aspect_ratios::ratio_16_10 and refresh_rate_mod == 0x01)
         value: (horiz_active_pixels_mod + 31) * 8
+        if: is_used
         doc: Range of horizontal active pixels.
       refresh_rate:
-        if: not (horiz_active_pixels_mod == 0x01 and aspect_ratio == aspect_ratios::ratio_16_10 and refresh_rate_mod == 0x01)
         value: refresh_rate_mod + 60
+        if: is_used
         doc: Vertical refresh rate, Hz.
     enums:
       aspect_ratios:

--- a/hardware/edid.ksy
+++ b/hardware/edid.ksy
@@ -10,7 +10,7 @@ seq:
   - id: magic
     contents: [0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00]
   - id: mfg_bytes
-    type: u2
+    type: u2be
   - id: product_code
     type: u2
     doc: Manufacturer product code
@@ -232,15 +232,17 @@ types:
           Aspect ratio of the image. Can be used to calculate number
           of vertical pixels.
       - id: refresh_rate_mod
-        type: b5
+        type: b6
         doc: |
           Refresh rate in Hz, written in modified form: `refresh_rate
           - 60`. This yields an effective range of 60..123 Hz.
     instances:
       horiz_active_pixels:
+        if: not (horiz_active_pixels_mod == 0x01 and aspect_ratio == aspect_ratios::ratio_16_10 and refresh_rate_mod == 0x01)
         value: (horiz_active_pixels_mod + 31) * 8
         doc: Range of horizontal active pixels.
       refresh_rate:
+        if: not (horiz_active_pixels_mod == 0x01 and aspect_ratio == aspect_ratios::ratio_16_10 and refresh_rate_mod == 0x01)
         value: refresh_rate_mod + 60
         doc: Vertical refresh rate, Hz.
     enums:


### PR DESCRIPTION
I explored https://en.wikipedia.org/wiki/Extended_Display_Identification_Data, fixed some issues and tested the result against a single EDID file.

`refresh_rate_mod` became `b6` because `u1` (`horiz_active_pixels_mod`) + `b2` (`aspect_ratio`) + `b6` (`refresh_rate_mod`) = `u2` as expected. Another evidence is that 123 - 60 = 63, and `b6` gives 2^6 = [0..63] in contrast to `b5` which gives 2^5 = [0..31].

If a standard timing equals to `01 01`, then it's marked as unused. It would be better to mark a whole `std_timing` as `null` in this case but I didn't find how to do that in http://doc.kaitai.io/ksy_diagram.html.