### PR TITLE
Add mach_o_fat format for multiarch Mach-O objects

### DIFF
--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -26,12 +26,13 @@ seq:
     repeat-expr: header.ncmds
 enums:
   magic_type:
+    # Note that for multiarch (a.k.a. fat) Mach-O files, which are the primary
+    # kind you find on macOS today, you should instead use mach_o_fat.ksy, which
+    # parses the fat header and embeds mach_o.ksy to parse each arch.
     0xFEEDFACE: macho_be_x86 # MH_MAGIC:    mach-o, big-endian,    x86
     0xCEFAEDFE: macho_le_x86 # MH_CIGAM:    mach-o, little-endian, x86
     0xFEEDFACF: macho_be_x64 # MH_MAGIC_64: mach-o, big-endian,    x64
     0xCFFAEDFE: macho_le_x64 # MH_CIGAM_64: mach-o, little-endian, x64
-    0xCAFEBABE: fat_be       # FAT_MAGIC:   fat,    big-endian
-    0xBEBAFECA: fat_le       # FAT_CIGAM:   fat,    little-endian
   cpu_type:
     0xffffffff: any
     1:          vax

--- a/executable/mach_o_fat.ksy
+++ b/executable/mach_o_fat.ksy
@@ -1,0 +1,50 @@
+meta:
+  id: mach_o_fat
+  title: macOS Mach-O multiarch ("fat") binary
+  license: CC0-1.0
+  imports:
+    - mach_o
+  endian: be
+
+doc: |
+  This is a simple container format that encapsulates multiple Mach-O files,
+  each generally for a different architecture. XNU can execute these files just
+  like single-arch Mach-Os and will pick the appropriate entry.
+
+doc-ref: https://opensource.apple.com/source/xnu/xnu-7195.121.3/EXTERNAL_HEADERS/mach-o/fat.h.auto.html
+
+seq:
+  - id: magic
+    contents: [0xca, 0xfe, 0xba, 0xbe]
+  - id: num_fat_arch
+    -orig-id: nfat_arch
+    type: u4
+  - id: fat_archs
+    type: fat_arch
+    repeat: expr
+    repeat-expr: num_fat_arch
+
+types:
+  fat_arch:
+    seq:
+      - id: cpu_type
+        -orig-id: cputype
+        type: u4
+        enum: mach_o::cpu_type
+      - id: cpu_subtype
+        -orig-id: cpusubtype
+        type: u4
+      - id: ofs_object
+        -orig-id: offset
+        type: u4
+      - id: len_object
+        -orig-id: size
+        type: u4
+      - id: align
+        type: u4
+
+    instances:
+      object:
+        pos: ofs_object
+        size: len_object
+        type: mach_o


### PR DESCRIPTION
Multiarch Mach-Os use a special "fat" container format. Currently, we recognize the magic for this in `mach_o.ksy` but then just try to parse it like a normal Mach-O, which fails. Since fat Mach-Os can't be nested inside themselves, I believe that a separate `ksy` to parse them is the correct approach. This PR adds such a `ksy`, which imports the existing Mach-O parser to parse each architecture.

This contribution is on behalf of my company.