### PR TITLE
java_class: add sanity check for the version number

### DIFF
--- a/executable/java_class.ksy
+++ b/executable/java_class.ksy
@@ -16,6 +16,7 @@ seq:
   - id: version_major
     type: u2
     valid:
+      # https://github.com/file/file/blob/905ca555/magic/Magdir/cafebabe#L11-L12
       min: 43
   - id: constant_pool_count
     type: u2

--- a/executable/java_class.ksy
+++ b/executable/java_class.ksy
@@ -15,6 +15,8 @@ seq:
     type: u2
   - id: version_major
     type: u2
+    valid:
+      min: 43
   - id: constant_pool_count
     type: u2
   - id: constant_pool


### PR DESCRIPTION
Mach-O files have the same magic bytes. This PR adds a sanity check to avoid false positives.