### PR TITLE
Resolve name collision

### DIFF
--- a/executable/microsoft_pe.ksy
+++ b/executable/microsoft_pe.ksy
@@ -372,7 +372,7 @@ types:
         0x0200:
           id: revision_2_0
           doc: Version 2 is the current version of the Win_Certificate structure.
-      certificate_type:
+      certificate_type_enum:
         0x0001:
           id: x509
           doc: |
@@ -402,7 +402,7 @@ types:
       - id: certificate_type
         -orig-id: wCertificateType
         type: u2
-        enum: certificate_type
+        enum: certificate_type_enum
         doc: Specifies the type of content in bCertificate
       - id: certificate_bytes
         -orig-id: bCertificate


### PR DESCRIPTION
 - Rename enum certificate_entry.certificate_type to certificate_entry.certificate_type_enum to avoid name collision with sequence field certificat_entry.certificate_type
 - Resolve compilation error in parser generated for csharp target