### PR TITLE
add .ksy for Adobe Flash video

### DIFF
--- a/media/flv.ksy
+++ b/media/flv.ksy
@@ -1,0 +1,63 @@
+meta:
+  id: flv
+  title: Adobe Flash Video File Format
+  license: CC0-1.0
+  ks-version: 0.9
+  encoding: utf-8
+  endian: be
+doc-ref: https://wwwimages2.adobe.com/content/dam/acom/en/devnet/flv/video_file_format_spec_v10_1.pdf
+seq:
+  - id: preheader
+    type: preheader
+  - id: rest_of_header
+    size: preheader.len_header - preheader._sizeof
+  - id: previous_tag_size0
+    type: u4
+    valid: 0
+  - id: tags
+    type: tag_and_size
+    repeat: eos
+types:
+  preheader:
+    seq:
+      - id: magic
+        contents: 'FLV'
+      - id: version
+        type: u1
+        valid: 1
+      - id: flags
+        type: u1
+      - id: len_header
+        type: u4
+  tag_and_size:
+    seq:
+      - id: tag
+        type: tag
+      - id: previous_tag_size
+        type: u4
+        valid: tag.len_data + 11
+  tag:
+    seq:
+      - id: reserved
+        type: b2
+      - id: filter
+        type: b1
+      - id: type
+        type: b5
+        enum: data_type
+      - id: len_data
+        type: b24
+      - id: timestamp
+        type: b24
+      - id: timestamp_extended
+        type: u1
+      - id: stream_id
+        type: b24
+        valid: 0
+      - id: data
+        size: len_data
+enums:
+  data_type:
+    8: audio
+    9: video
+    18: script


### PR DESCRIPTION
A fairly simplistic .ksy for Adobe flash video. This only checks the container structure, but doesn't parse the invididual video audio and script data elements.