### PR TITLE
fix TTF parsing bugs

### DIFF
--- a/font/ttf.ksy
+++ b/font/ttf.ksy
@@ -824,6 +824,14 @@ types:
       - id: num_glyphs
         type: u2
         doc: 'The number of glyphs in the font.'
+      - id: version10_body
+        type: maxp_version10_body
+        if: version10
+    instances:
+      version10:
+        value: table_version_number.major == 1 and table_version_number.minor == 0
+  maxp_version10_body:
+    seq:
       - id: max_points
         type: u2
         doc: 'Maximum points in a non-composite glyph.'

--- a/font/ttf.ksy
+++ b/font/ttf.ksy
@@ -826,9 +826,9 @@ types:
         doc: 'The number of glyphs in the font.'
       - id: version10_body
         type: maxp_version10_body
-        if: version10
+        if: is_version10
     instances:
-      version10:
+      is_version10:
         value: table_version_number.major == 1 and table_version_number.minor == 0
   maxp_version10_body:
     seq:

--- a/font/ttf.ksy
+++ b/font/ttf.ksy
@@ -895,7 +895,7 @@ types:
           - id: glyph_names
             type: pascal_string
             repeat: until
-            repeat-until: _.length == 0
+            repeat-until: _.length == 0 or _io.eof
     seq:
       - id: format
         type: fixed


### PR DESCRIPTION
This fixes two bugs with parsing ttf files:

* parsing fonts with `maxp` version 0.5 tables
* reading `post` tables, where it was attempted to read data beyond the end of the stream