### PR TITLE
Ttf updates

### DIFF
--- a/font/ttf.ksy
+++ b/font/ttf.ksy
@@ -318,7 +318,19 @@ types:
           signature:
             pos: ofs_signature
             size: len_signature
-            io: _root._io
+            type: signature_block
+      signature_block:
+        seq:
+          - id: reserved1
+            type: u2
+            valid: 0
+          - id: reserved2
+            type: u2
+            valid: 0
+          - id: len_signature
+            type: u4
+          - id: signature
+            size: len_signature
   glyf:
     # https://github.com/fonttools/fonttools/blob/678876325ef26ac33e8c6d13f4fb70c3bef5da8e/Lib/fontTools/ttLib/tables/_g_l_y_f.py
     # TODO: sadly, Kaitai currently cannot parse this structure

--- a/font/ttf.ksy
+++ b/font/ttf.ksy
@@ -11,7 +11,9 @@ meta:
 doc: |
   A TrueType font file contains data, in table format, that comprises
   an outline font.
-doc-ref: https://www.microsoft.com/typography/tt/ttf_spec/ttch02.doc
+doc-ref:
+  - https://www.microsoft.com/typography/tt/ttf_spec/ttch02.doc
+  - https://docs.microsoft.com/en-us/typography/opentype/spec/
 seq:
   - id: offset_table
     type: offset_table

--- a/font/ttf.ksy
+++ b/font/ttf.ksy
@@ -62,6 +62,7 @@ types:
           cases:
             "'cmap'": cmap
             "'cvt '": cvt
+            "'DSIG'": dsig
             "'glyf'": glyf
             "'head'": head
             "'hhea'": hhea
@@ -193,6 +194,33 @@ types:
       - id: fwords
         type: s2
         repeat: eos
+  dsig:
+    seq:
+      - id: version
+        type: u4
+        valid: 1
+      - id: num_signatures
+        type: u2
+      - id: flags
+        type: u2
+      - id: signature_records
+        type: signature_record
+        repeat: expr
+        repeat-expr: num_signatures
+    types:
+      signature_record:
+        seq:
+          - id: format
+            type: u4
+          - id: len_signature
+            type: u4
+          - id: ofs_signature
+            type: u4
+        instances:
+          signature:
+            pos: ofs_signature
+            size: len_signature
+            io: _root._io
   glyf:
     # https://github.com/fonttools/fonttools/blob/678876325ef26ac33e8c6d13f4fb70c3bef5da8e/Lib/fontTools/ttLib/tables/_g_l_y_f.py
     # TODO: sadly, Kaitai currently cannot parse this structure

--- a/font/ttf.ksy
+++ b/font/ttf.ksy
@@ -120,6 +120,7 @@ types:
                 subtable_format::trimmed_array: trimmed_array
                 subtable_format::segmented_coverage: segmented_coverage
                 subtable_format::many_to_one_range_mappings: segmented_coverage
+                subtable_format::unicode_variation_sequences: unicode_variation_sequences
         enums:
           subtable_format:
             0: byte_encoding_table
@@ -282,7 +283,31 @@ types:
                         type: u4
                       - id: start_glyph_id
                         type: u4
-          #unicode_variation_sequences:
+          unicode_variation_sequences:
+            seq:
+              - id: length
+                type: u4
+              - id: body
+                type: body
+                size: length - length._sizeof - _parent.format._sizeof
+            types:
+              body:
+                seq:
+                  - id: num_variation_selector_records
+                    type: u4
+                  - id: variation_selector_records
+                    type: variation_selector_record
+                    repeat: expr
+                    repeat-expr: num_variation_selector_records
+                types:
+                  variation_selector_record:
+                    seq:
+                      - id: var_selector
+                        type: b24
+                      - id: ofs_default_uvs_table
+                        type: u4
+                      - id: ofs_non_default_uvs_table
+                        type: u4
   cvt:
     doc: >
       cvt  - Control Value Table

--- a/font/ttf.ksy
+++ b/font/ttf.ksy
@@ -778,7 +778,29 @@ types:
         doc: 'The descender metric for Windows.'
       - id: code_page_range
         type: code_page_range
+        if: version > 0
         doc: 'This field is used to specify the code pages encompassed by the font file in the `cmap` subtable for platform 3, encoding ID 1 (Microsoft platform).'
+      - id: x_height
+        type: u2
+        if: version > 1
+      - id: cap_height
+        type: u2
+        if: version > 1
+      - id: default_char
+        type: u2
+        if: version > 1
+      - id: break_char
+        type: u2
+        if: version > 1
+      - id: max_context
+        type: u2
+        if: version > 1
+      - id: lower_optical_point_size
+        type: u2
+        if: version > 4
+      - id: upper_optical_point_size
+        type: u2
+        if: version > 4
   prep:
     seq:
       - id: instructions


### PR DESCRIPTION
This commit adds/fixes:

* support for `dsig` table
* support for `OS/2` table version 0, 2, 3, 4, 5 (previously only version 1 was supported, which led to parsing errors for version 0 tables)
* rework `cmap` table: there are other formats of TTF files that were not supported, leading to parse errors. Support for some formats was (partially) added