### PR TITLE
DOS MZ updates

### DIFF
--- a/executable/dos_mz.ksy
+++ b/executable/dos_mz.ksy
@@ -11,6 +11,7 @@ meta:
   tags:
     - dos
   license: CC0-1.0
+  ks-version: 0.9
   endian: le
 doc: |
   DOS MZ file format is a traditional format for executables in MS-DOS
@@ -21,22 +22,32 @@ doc: |
   segment of raw CPU instructions), DOS MZ .exe file format allowed
   more flexible memory management, loading of larger programs and
   added support for relocations.
+doc-ref:
+  - http://www.delorie.com/djgpp/doc/exe/
 seq:
-  - id: hdr
-    type: mz_header
-  - id: mz_header2
-    size: hdr.ofs_relocations - 0x1c
-  - id: relocations
-    type: relocation
-    repeat: expr
-    repeat-expr: hdr.num_relocations
+  - id: header
+    type: exe_header
   - id: body
     size-eos: true
+instances:
+  relocations:
+    pos: header.mz.ofs_relocations
+    io: header._io
+    type: relocation
+    repeat: expr
+    repeat-expr: header.mz.num_relocations
+    if: header.mz.ofs_relocations != 0
 types:
+  exe_header:
+    seq:
+      - id: mz
+        type: mz_header
+      - id: rest_of_header
+        size: mz.len_header - mz._sizeof
   mz_header:
     seq:
       - id: magic
-        size: 2
+        contents: 'MZ'
       - id: last_page_extra_bytes
         type: u2
       - id: num_pages
@@ -63,15 +74,12 @@ types:
         type: u2
       - id: overlay_id
         type: u2
+    instances:
+      len_header:
+        value: header_size * 16
   relocation:
     seq:
       - id: ofs
         type: u2
       - id: seg
         type: u2
-#instances:
-#  relocations:
-#    pos: ofs_relocations
-#    type: relocation
-#    repeat: expr
-#    repeat-expr: hdr.num_relocations

--- a/executable/dos_mz.ksy
+++ b/executable/dos_mz.ksy
@@ -28,7 +28,7 @@ seq:
   - id: header
     type: exe_header
   - id: body
-    size-eos: true
+    size: header.len_body
 instances:
   relocations:
     pos: header.mz.ofs_relocations
@@ -44,6 +44,9 @@ types:
         type: mz_header
       - id: rest_of_header
         size: mz.len_header - mz._sizeof
+    instances:
+      len_body:
+        value: (mz.last_page_extra_bytes == 0 ? mz.num_pages * 512 : (mz.num_pages - 1) * 512 + mz.last_page_extra_bytes) - mz.len_header
   mz_header:
     seq:
       - id: magic

--- a/executable/dos_mz.ksy
+++ b/executable/dos_mz.ksy
@@ -46,7 +46,7 @@ types:
         size: mz.len_header - mz._sizeof
     instances:
       len_body:
-        value: (mz.last_page_extra_bytes == 0 ? mz.num_pages * 512 : (mz.num_pages - 1) * 512 + mz.last_page_extra_bytes) - mz.len_header
+        value: '(mz.last_page_extra_bytes == 0 ? mz.num_pages * 512 : (mz.num_pages - 1) * 512 + mz.last_page_extra_bytes) - mz.len_header'
   mz_header:
     seq:
       - id: magic

--- a/executable/dos_mz.ksy
+++ b/executable/dos_mz.ksy
@@ -12,6 +12,7 @@ meta:
     - dos
   license: CC0-1.0
   ks-version: 0.9
+  encoding: ASCII
   endian: le
 doc: |
   DOS MZ file format is a traditional format for executables in MS-DOS
@@ -22,8 +23,7 @@ doc: |
   segment of raw CPU instructions), DOS MZ .exe file format allowed
   more flexible memory management, loading of larger programs and
   added support for relocations.
-doc-ref:
-  - http://www.delorie.com/djgpp/doc/exe/
+doc-ref: http://www.delorie.com/djgpp/doc/exe/
 seq:
   - id: header
     type: exe_header
@@ -47,7 +47,12 @@ types:
   mz_header:
     seq:
       - id: magic
-        contents: 'MZ'
+        size: 2
+        type: str
+        valid:
+          any-of:
+            - '"MZ"'
+            - '"ZM"'
       - id: last_page_extra_bytes
         type: u2
       - id: num_pages


### PR DESCRIPTION
This updates fixes the magic and reworks the header which also corrects the offsets of the body.

The previous version did not work for various executables used in FreeDOS 1.2 like `PING.EXE`. These are now correctly (or: "more correctly") parsed.

The biggest change is reworking the header and to look at the actual length of the header (for which a separate `len_header` instance was created). According to <http://www.delorie.com/djgpp/doc/exe/>:

```
 The header includes the relocation entries.
```