### PR TITLE
java_class: improve is_two_entries to prevent 'ConstantPoolEntry' object has no attribute 'tag' error in generated Python code

### DIFF
--- a/executable/java_class.ksy
+++ b/executable/java_class.ksy
@@ -83,7 +83,7 @@ types:
         if: not is_prev_two_entries
     instances:
       is_two_entries:
-        value: 'tag == tag_enum::long or tag == tag_enum::double'
+        value: 'is_prev_two_entries ? false : tag == tag_enum::long or tag == tag_enum::double'
     enums:
       tag_enum:
         7: class_type


### PR DESCRIPTION
I bumped into an error where when using a Python generated with the `.ksy` I would get an error: `"ConstantPoolEntry' object has no attribute 'tag'` for the second entry of entries that take up two entries (`long` and `double`).

The generated code looks like this:

```python
@property
 def is_two_entries(self):
        if hasattr(self, '_m_is_two_entries'):
            return self._m_is_two_entries if hasattr(self, '_m_is_two_entries') else None

        self._m_is_two_entries =  ((self.tag == JavaClass.ConstantPoolEntry.TagEnum.long) or (self.tag == JavaClass.ConstantPoolEntry.TagEnum.double)) 
        return self._m_is_two_entries if hasattr(self, '_m_is_two_entries') else None
```

The problem here is that it tries to find `self.tag` which doesn't exist for these "second entries":

```python
def _read(self):
    if not (self.is_prev_two_entries):
        self.tag = KaitaiStream.resolve_enum(JavaClass.ConstantPoolEntry.TagEnum, self._io.read_u1())
```

As you can see `self.tag` does not exist for these entries.

In the Web IDE this is not a problem.