### PR TITLE
add the Android Nano app header

### DIFF
--- a/executable/android_nanoapp_header.ksy
+++ b/executable/android_nanoapp_header.ksy
@@ -1,11 +1,13 @@
 meta:
-  id: napp_header
-  title: Nano App header
+  id: android_nanoapp_header
+  title: Android nanoapp header
   file-extension: napp_header
+  tags:
+    - android
+    - executable
   license: Apache-2.0
   ks-version: 0.9
   endian: le
-  encoding: UTF-8
 doc-ref: https://android.googlesource.com/platform/system/chre/+/a7ff61b9/build/build_template.mk#130
 seq:
   - id: header_version

--- a/executable/napp_header.ksy
+++ b/executable/napp_header.ksy
@@ -29,8 +29,8 @@ seq:
     contents: [0, 0, 0, 0, 0, 0]
 instances:
   is_signed:
-    value: flags & 0x1 == 0x1
+    value: flags & 0x1 != 0
   is_encrypted:
-    value: flags & 0x2 == 0x2
+    value: flags & 0x2 != 0
   is_tcm_capable:
-    value: flags & 0x4 == 0x4
+    value: flags & 0x4 != 0

--- a/executable/napp_header.ksy
+++ b/executable/napp_header.ksy
@@ -6,7 +6,7 @@ meta:
   ks-version: 0.9
   endian: le
   encoding: UTF-8
-doc-ref: https://android.googlesource.com/platform/system/chre/+/a7ff61b94d6658597c63ae0a15bdee3cdfbaa8c7/build/build_template.mk#130
+doc-ref: https://android.googlesource.com/platform/system/chre/+/a7ff61b9/build/build_template.mk#130
 seq:
   - id: header_version
     type: u4

--- a/executable/napp_header.ksy
+++ b/executable/napp_header.ksy
@@ -1,0 +1,36 @@
+meta:
+  id: napp_header
+  title: Nano App header
+  file-extension: napp_header
+  license: Apache-2.0
+  ks-version: 0.9
+  endian: le
+  encoding: UTF-8
+doc-ref: https://android.googlesource.com/platform/system/chre/+/a7ff61b94d6658597c63ae0a15bdee3cdfbaa8c7/build/build_template.mk#130
+seq:
+  - id: header_version
+    type: u4
+    valid: 1
+  - id: magic
+    contents: "NANO"
+  - id: app_id
+    type: u8
+  - id: app_version
+    type: u4
+  - id: flags
+    type: u4
+  - id: hub_type
+    type: u8
+  - id: chre_api_major_version
+    type: u1
+  - id: chre_api_minor_version
+    type: u1
+  - id: reserved
+    contents: [0, 0, 0, 0, 0, 0]
+instances:
+  is_signed:
+    value: flags & 0x1 == 0x1
+  is_encrypted:
+    value: flags & 0x2 == 0x2
+  is_tcm_capable:
+    value: flags & 0x4 == 0x4


### PR DESCRIPTION
This adds a description of the Google nano app header, a file sometimes seen in Android devices using the Context Hun Runtime Environment (CHRE) <https://source.android.com/devices/contexthub>.

Test files can be found inside the `vendor.img` file of this recent Android 12L factory image: <https://dl.google.com/dl/android/aosp/oriole-sp2a.220405.004-factory-f560807e.zip>