### PR TITLE
zisofs: add specification

### DIFF
--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -61,13 +61,16 @@ types:
         value: '(uncompressed_size / block_size) + (uncompressed_size % block_size != 0 ? 1 : 0)'
         doc: ceil(uncompressed_size / block_size)
   block:
+    -webide-representation: '[{ofs_start}, {ofs_end}): {len_data:dec} bytes'
     params:
       - id: ofs_start
         type: u4
       - id: ofs_end
         type: u4
     instances:
+      len_data:
+        value: ofs_end - ofs_start
       data:
         io: _root._io
         pos: ofs_start
-        size: ofs_end - ofs_start
+        size: len_data

--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -4,6 +4,9 @@ meta:
   xref:
     justsolve: Zisofs
     wikidata: Q105854284
+  tags:
+    - archive
+    - filesystem
   license: CC0-1.0
   endian: le
 doc: |

--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -17,8 +17,8 @@ doc: |
 doc-ref: https://web.archive.org/web/20200612093441/https://dev.lovelyhq.com/libburnia/web/-/wikis/zisofs
 seq:
   - id: header
-    type: header
     size: 16
+    type: header
   - id: block_pointers
     type: u4
     repeat: expr
@@ -65,6 +65,6 @@ types:
       len_block:
         value: 'index < _parent.block_pointers.size - 1 ? _parent.block_pointers[index+1] - _parent.block_pointers[index] : _parent.final_block_pointer - _parent.block_pointers[index]'
       data:
-        pos: _parent.block_pointers[index]
         io: _root._io
+        pos: _parent.block_pointers[index]
         size: len_block

--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -19,7 +19,7 @@ doc: |
   The specification here describes the structure of a file that has been
   preprocessed by mkzftree, not of a full ISO9660 ziso. Data is not
   decompressed, as blocks with length 0 have a special meaning. Decompressing
-  and deconstruction this data should be done outside of Kaitai Struct.
+  and deconstruction of this data should be done outside of Kaitai Struct.
 doc-ref: https://web.archive.org/web/20200612093441/https://dev.lovelyhq.com/libburnia/web/-/wikis/zisofs
 seq:
   - id: header

--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -1,0 +1,68 @@
+meta:
+  id: zisofs
+  title: zisofs
+  license: CC0-1.0
+  endian: le
+doc: |
+  zisofs is a compression format for files on ISO9660 file system. It has
+  limited support across operating systems, mainly Linux kernel. Typically a
+  directory tree is first preprocessed by mkzftree (from the zisofs-tools
+  package before being turned into an ISO9660 image by mkisofs, genisoimage
+  or similar tool. The data is zlib compressed.
+
+  The specification here describes the structure of a file that has been
+  preprocessed by mkzftree, not of a full ISO9660 ziso. Data is not
+  decompressed, as blocks with length 0 have a special meaning. Decompressing
+  and deconstruction this data should be done outside of Kaitai Struct.
+doc-ref: https://web.archive.org/web/20200612093441/https://dev.lovelyhq.com/libburnia/web/-/wikis/zisofs
+seq:
+  - id: header
+    type: header
+    size: 16
+  - id: block_pointers
+    type: u4
+    repeat: expr
+    repeat-expr: header.num_block_pointers
+  - id: final_block_pointer
+    type: u4
+    doc: |
+      Final pointer indicating the first invalid byte. Typically this is
+      also the end of the file data.
+instances:
+  blocks:
+    type: block_pointer(_index)
+    repeat: expr
+    repeat-expr: header.num_block_pointers
+types:
+  header:
+    seq:
+      - id: magic
+        contents: [0x37, 0xe4, 0x53, 0x96, 0xc9, 0xdb, 0xd6, 0x07]
+      - id: uncompressed_size
+        type: u4
+        doc: Size of the original uncompressed file
+      - id: len_header
+        type: u1
+        valid: 4
+        doc: header_size >> 2 (currently 4)
+      - id: log2_block_size
+        type: u1
+      - id: reserved
+        contents: [0, 0]
+    instances:
+      block_size:
+        value: 2 << (log2_block_size - 1)
+      num_block_pointers:
+        value: 'uncompressed_size % block_size == 0 ? (uncompressed_size / block_size) : (uncompressed_size / block_size) + 1'
+        doc: ceil(uncompressed_size / block_size)
+  block_pointer:
+    params:
+      - id: index
+        type: u4
+    instances:
+      len_block:
+        value: 'index < _parent.block_pointers.size - 1 ? _parent.block_pointers[index+1] - _parent.block_pointers[index] : _parent.final_block_pointer - _parent.block_pointers[index]'
+      data:
+        pos: _parent.block_pointers[index]
+        io: _root._io
+        size: len_block

--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -49,7 +49,7 @@ types:
         type: u1
         valid: 4
         doc: header_size >> 2 (currently 4)
-      - id: log2_block_size
+      - id: block_size_log2
         type: u1
         valid:
           any-of: [15, 16, 17]
@@ -57,7 +57,7 @@ types:
         contents: [0, 0]
     instances:
       block_size:
-        value: 1 << log2_block_size
+        value: 1 << block_size_log2
       num_blocks:
         value: '(uncompressed_size / block_size) + (uncompressed_size % block_size != 0 ? 1 : 0)'
         doc: ceil(uncompressed_size / block_size)

--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -18,7 +18,7 @@ doc: |
 
   The specification here describes the structure of a file that has been
   preprocessed by mkzftree, not of a full ISO9660 ziso. Data is not
-  decompressed, as blocks with length 0 have a special meaning. Decompressing
+  decompressed, as blocks with length 0 have a special meaning. Decompression
   and deconstruction of this data should be done outside of Kaitai Struct.
 doc-ref: https://web.archive.org/web/20200612093441/https://dev.lovelyhq.com/libburnia/web/-/wikis/zisofs
 seq:

--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -1,6 +1,9 @@
 meta:
   id: zisofs
   title: zisofs
+  xref:
+    justsolve: Zisofs
+    wikidata: Q105854284
   license: CC0-1.0
   endian: le
 doc: |

--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -53,9 +53,9 @@ types:
         contents: [0, 0]
     instances:
       block_size:
-        value: 2 << (log2_block_size - 1)
+        value: 1 << log2_block_size
       num_block_pointers:
-        value: 'uncompressed_size % block_size == 0 ? (uncompressed_size / block_size) : (uncompressed_size / block_size) + 1'
+        value: '(uncompressed_size / block_size) + (uncompressed_size % block_size != 0 ? 1 : 0)'
         doc: ceil(uncompressed_size / block_size)
   block_pointer:
     params:
@@ -63,7 +63,10 @@ types:
         type: u4
     instances:
       len_block:
-        value: 'index < _parent.block_pointers.size - 1 ? _parent.block_pointers[index+1] - _parent.block_pointers[index] : _parent.final_block_pointer - _parent.block_pointers[index]'
+        value: |
+          (index < _parent.block_pointers.size - 1
+            ? _parent.block_pointers[index + 1]
+            : _parent.final_block_pointer) - _parent.block_pointers[index]
       data:
         io: _root._io
         pos: _parent.block_pointers[index]

--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -47,6 +47,8 @@ types:
         doc: header_size >> 2 (currently 4)
       - id: log2_block_size
         type: u1
+        valid:
+          any-of: [15, 16, 17]
       - id: reserved
         contents: [0, 0]
     instances:

--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -28,17 +28,15 @@ seq:
   - id: block_pointers
     type: u4
     repeat: expr
-    repeat-expr: header.num_block_pointers
-  - id: final_block_pointer
-    type: u4
+    repeat-expr: header.num_blocks + 1
     doc: |
-      Final pointer indicating the first invalid byte. Typically this is
-      also the end of the file data.
+      The final pointer (`block_pointers[header.num_blocks]`) indicates the end
+      of the last block. Typically this is also the end of the file data.
 instances:
   blocks:
-    type: 'block(block_pointers[_index], _index < header.num_block_pointers - 1 ? block_pointers[_index + 1] : final_block_pointer)'
+    type: 'block(block_pointers[_index], block_pointers[_index + 1])'
     repeat: expr
-    repeat-expr: header.num_block_pointers
+    repeat-expr: header.num_blocks
 types:
   header:
     seq:
@@ -60,7 +58,7 @@ types:
     instances:
       block_size:
         value: 1 << log2_block_size
-      num_block_pointers:
+      num_blocks:
         value: '(uncompressed_size / block_size) + (uncompressed_size % block_size != 0 ? 1 : 0)'
         doc: ceil(uncompressed_size / block_size)
   block:

--- a/archive/zisofs.ksy
+++ b/archive/zisofs.ksy
@@ -30,7 +30,7 @@ seq:
       also the end of the file data.
 instances:
   blocks:
-    type: block_pointer(_index)
+    type: 'block(block_pointers[_index], _index < header.num_block_pointers - 1 ? block_pointers[_index + 1] : final_block_pointer)'
     repeat: expr
     repeat-expr: header.num_block_pointers
 types:
@@ -57,17 +57,14 @@ types:
       num_block_pointers:
         value: '(uncompressed_size / block_size) + (uncompressed_size % block_size != 0 ? 1 : 0)'
         doc: ceil(uncompressed_size / block_size)
-  block_pointer:
+  block:
     params:
-      - id: index
+      - id: ofs_start
+        type: u4
+      - id: ofs_end
         type: u4
     instances:
-      len_block:
-        value: |
-          (index < _parent.block_pointers.size - 1
-            ? _parent.block_pointers[index + 1]
-            : _parent.final_block_pointer) - _parent.block_pointers[index]
       data:
         io: _root._io
-        pos: _parent.block_pointers[index]
-        size: len_block
+        pos: ofs_start
+        size: ofs_end - ofs_start


### PR DESCRIPTION
This PR adds a specification for zisofs compressed files. I have put it in `archive` as I think that this might be the best place, as it processes a single file that has been compressed with `mkzftree`. That being said, I could imagine it being conceptually belonging to `filesystem`, so if you want to move it, go ahead.

<http://fileformats.archiveteam.org/wiki/Zisofs>