### PR TITLE
ds_store: fix array index type issue in some target languages

### DIFF
--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -167,7 +167,7 @@ types:
         instances:
           block:
             io: _root._io
-            pos: _root.buddy_allocator_body.block_addresses[block_id].offset
+            pos: _root.buddy_allocator_body.block_addresses[block_id.as<u4>].offset
             type: block
             if: mode > 0
         types:


### PR DESCRIPTION
This PR fixes an issue related to some array index type conversions in Java.

See https://github.com/kaitai-io/kaitai_struct/issues/956 for further information.