### PR TITLE
DS_Store - Fix block size computation

### DIFF
--- a/macos/ds_store.ksy
+++ b/macos/ds_store.ksy
@@ -81,7 +81,7 @@ types:
           offset:
             value: (address_raw & ~_root.block_address_mask) + 4
           size:
-            value: 1 << address_raw & _root.block_address_mask
+            value: 1 << (address_raw & _root.block_address_mask)
       directory_entry:
         seq:
           - id: len_name


### PR DESCRIPTION
Hi,

Missing parentheses in the `.DS_Store` file description cause wrong computation of block sizes.

I was quite surprised to find this bug, as everything worked well when I submitted the file description to the format gallery years ago. I tried to reproduce the setup I used at that time (Kaitai Struct compiler and runtime in version 0.8, etc.), but in vain. Just like if the bug has always been there. Anyway, this PR fixes the issue.

You can find sample files for testing in my original PR (https://github.com/kaitai-io/kaitai_struct_formats/pull/131).

Thanks.