### PR TITLE
Replace `docs.microsoft.com` with `learn.microsoft.com`

### DIFF
--- a/common/dos_datetime.ksy
+++ b/common/dos_datetime.ksy
@@ -39,8 +39,8 @@ doc: |
     - [cab](http://justsolve.archiveteam.org/wiki/Cabinet)
 
 doc-ref:
-  - https://docs.microsoft.com/en-us/windows/win32/sysinfo/ms-dos-date-and-time
-  - https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-dosdatetimetofiletime
+  - https://learn.microsoft.com/en-us/windows/win32/sysinfo/ms-dos-date-and-time
+  - https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-dosdatetimetofiletime
   - https://github.com/reactos/reactos/blob/c6b6444/dll/win32/kernel32/client/time.c#L82-L87 DosDateTimeToFileTime
   - https://download.microsoft.com/download/0/8/4/084c452b-b772-4fe5-89bb-a0cbf082286a/fatgen103.doc page 25/34
 -webide-representation: "{date} {time}"

--- a/executable/microsoft_pe.ksy
+++ b/executable/microsoft_pe.ksy
@@ -16,7 +16,7 @@ meta:
   license: CC0-1.0
   ks-version: 0.7
   endian: le
-doc-ref: https://docs.microsoft.com/en-us/windows/win32/debug/pe-format
+doc-ref: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format
 seq:
   - id: mz
     type: mz_placeholder
@@ -363,7 +363,7 @@ types:
         type: certificate_entry
         repeat: eos
   certificate_entry:
-    doc-ref: 'https://docs.microsoft.com/en-us/windows/desktop/debug/pe-format#the-attribute-certificate-table-image-only'
+    doc-ref: 'https://learn.microsoft.com/en-us/windows/desktop/debug/pe-format#the-attribute-certificate-table-image-only'
     enums:
       certificate_revision:
         0x0100:

--- a/image/bmp.ksy
+++ b/image/bmp.ksy
@@ -76,7 +76,7 @@ doc: |
 
   ## Specs
    * [Bitmap Storage (Windows Dev Center)](
-       https://docs.microsoft.com/en-us/windows/win32/gdi/bitmap-storage
+       https://learn.microsoft.com/en-us/windows/win32/gdi/bitmap-storage
      )
       * BITMAPFILEHEADER
       * BITMAPINFOHEADER
@@ -114,7 +114,7 @@ types:
       There is a proposal for adding bitmap data type to Kaitai Struct: https://github.com/kaitai-io/kaitai_struct/issues/188
   file_header:
     -orig-id: BITMAPFILEHEADER
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapfileheader
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapfileheader
     seq:
       - id: file_type
         -orig-id: bfType
@@ -135,7 +135,7 @@ types:
         doc: Offset to actual raw pixel data of the image
   bitmap_info:
     -orig-id: BITMAPINFO
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfo
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfo
     seq:
       - id: len_header
         type: u4
@@ -208,7 +208,7 @@ types:
       - BITMAPCOREHEADER
       - OS21XBITMAPHEADER
     doc-ref:
-      - https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapcoreheader
+      - https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapcoreheader
       - https://www.fileformat.info/format/os2bmp/egff.htm#OS2BMP-DMYID.3.1
     params:
       - id: len_header
@@ -278,7 +278,7 @@ types:
           and not (extends_bitmap_info and not extends_os2_2x_bitmap and (bitmap_info_ext.compression == compressions::jpeg or bitmap_info_ext.compression == compressions::png))
   bitmap_info_extension:
     -orig-id: BITMAPINFOHEADER
-    doc-ref: https://docs.microsoft.com/en-us/previous-versions/dd183376(v=vs.85)
+    doc-ref: https://learn.microsoft.com/en-us/previous-versions/dd183376(v=vs.85)
     seq:
       - id: compression
         -orig-id: biCompression
@@ -352,7 +352,7 @@ types:
 
   bitmap_v4_extension:
     -orig-id: BITMAPV4HEADER
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv4header
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv4header
     seq:
       - id: color_space_type
         -orig-id: bV4CSType
@@ -376,7 +376,7 @@ types:
 
   cie_xyz:
     -orig-id: CIEXYZ
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-ciexyz
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-ciexyz
     seq:
       - id: x
         type: fixed_point_2_dot_30
@@ -389,7 +389,7 @@ types:
     meta:
       encoding: windows-1252 # for the file name of linked profile (see profile_data below)
     -orig-id: BITMAPV5HEADER
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header
     seq:
       - id: intent
         -orig-id: bV5Intent
@@ -419,7 +419,7 @@ types:
           cases:
             true: strz
         if: has_profile
-        doc-ref: https://docs.microsoft.com/en-us/windows/win32/wcs/using-structures-in-wcs-1-0 "If the profile is embedded,
+        doc-ref: https://learn.microsoft.com/en-us/windows/win32/wcs/using-structures-in-wcs-1-0 "If the profile is embedded,
           profile data is the actual profile, and if it is linked, the profile data is the
           null-terminated file name of the profile. This cannot be a Unicode string. It must be composed exclusively
           of characters from the Windows character set (code page 1252)."
@@ -495,7 +495,7 @@ types:
     -webide-representation: "{value}"
 enums:
   compressions:
-    # https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header (search for bV5Compression)
+    # https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header (search for bV5Compression)
     0:
       id: rgb
       -orig-id: BI_RGB
@@ -552,7 +552,7 @@ enums:
       id: super_circle
 
   color_space:
-    # https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header#members
+    # https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header#members
   # For BITMAPV4HEADER:
     0:
       id: calibrated_rgb
@@ -583,7 +583,7 @@ enums:
         This value indicates that bV5ProfileData points to a memory buffer that contains
         the profile to be used (gamma and endpoints values are ignored).
   intent:
-    # https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header#members
+    # https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header#members
     8:
       id: abs_colorimetric
       -orig-id: LCS_GM_ABS_COLORIMETRIC

--- a/image/ico.ksy
+++ b/image/ico.ksy
@@ -18,7 +18,7 @@ doc: |
   icons - ICO. This is a container that contains one or more image
   files (effectively, DIB parts of BMP files or full PNG files are
   contained inside).
-doc-ref: https://docs.microsoft.com/en-us/previous-versions/ms997538(v=msdn.10)
+doc-ref: https://learn.microsoft.com/en-us/previous-versions/ms997538(v=msdn.10)
 seq:
   - id: magic
     contents: [0, 0, 1, 0]

--- a/log/windows_evt_log.ksy
+++ b/log/windows_evt_log.ksy
@@ -26,14 +26,14 @@ doc: |
   file using relevant option in Event Viewer application.
 
   A Windows application can submit an entry into these logs using
-  [ReportEventA](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-reporteventa)
+  [ReportEventA](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-reporteventa)
   function of Windows API.
 
   Internally, EVT files consist of a fixed-size header and event
   records. There are several usage scenarios (non-wrapping vs wrapping
   log files) which result in slightly different organization of
   records.
-doc-ref: https://docs.microsoft.com/en-us/windows/win32/eventlog/event-log-file-format
+doc-ref: https://learn.microsoft.com/en-us/windows/win32/eventlog/event-log-file-format
 seq:
   - id: header
     type: header
@@ -42,7 +42,7 @@ seq:
     repeat: eos
 types:
   header:
-    doc-ref: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/bb309024(v=vs.85)
+    doc-ref: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/bb309024(v=vs.85)
     seq:
       - id: len_header
         -orig-id: HeaderSize
@@ -113,7 +113,7 @@ types:
               True if write operation was in progress, but log file
               wasn't properly closed.
   record:
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-eventlogrecord
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-eventlogrecord
     seq:
       - id: len_record
         -orig-id: Length
@@ -141,7 +141,7 @@ types:
         type: u4
         doc: Size of whole record again.
   record_body:
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-eventlogrecord
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-eventlogrecord
     seq:
       - id: idx
         -orig-id: RecordNumber
@@ -166,7 +166,7 @@ types:
         type: u2
         enum: event_types
         doc: Type of event.
-        doc-ref: https://docs.microsoft.com/en-us/windows/win32/eventlog/event-types
+        doc-ref: https://learn.microsoft.com/en-us/windows/win32/eventlog/event-types
       - id: num_strings
         -orig-id: NumStrings
         type: u2
@@ -174,7 +174,7 @@ types:
       - id: event_category
         -orig-id: EventCategory
         type: u2
-        doc-ref: https://docs.microsoft.com/en-us/windows/win32/eventlog/event-categories
+        doc-ref: https://learn.microsoft.com/en-us/windows/win32/eventlog/event-categories
       - id: reserved
         -orig-id: ReservedFlags, ClosingRecordNumber
         size: 6

--- a/media/avi.ksy
+++ b/media/avi.ksy
@@ -11,7 +11,7 @@ meta:
   license: CC0-1.0
   ks-version: 0.7
   endian: le
-doc-ref: https://docs.microsoft.com/en-us/previous-versions/ms779636(v=vs.85)
+doc-ref: https://learn.microsoft.com/en-us/previous-versions/ms779636(v=vs.85)
 seq:
   - id: magic1
     contents: RIFF
@@ -53,7 +53,7 @@ types:
         type: blocks
   avih_body:
     doc: Main header of an AVI file, defined as AVIMAINHEADER structure
-    doc-ref: https://docs.microsoft.com/en-us/previous-versions/ms779632(v=vs.85)
+    doc-ref: https://learn.microsoft.com/en-us/previous-versions/ms779632(v=vs.85)
     seq:
       - id: micro_sec_per_frame
         type: u4
@@ -79,7 +79,7 @@ types:
         size: 16
   strh_body:
     doc: Stream header (one header per stream), defined as AVISTREAMHEADER structure
-    doc-ref: https://docs.microsoft.com/en-us/previous-versions/ms779638(v=vs.85)
+    doc-ref: https://learn.microsoft.com/en-us/previous-versions/ms779638(v=vs.85)
     seq:
       - id: fcc_type
         type: u4

--- a/network/dime_message.ksy
+++ b/network/dime_message.ksy
@@ -23,7 +23,7 @@ doc: |
   && gunzip scanner_withoptions.dump.gz`
 doc-ref:
   - https://tools.ietf.org/html/draft-nielsen-dime-02
-  - https://docs.microsoft.com/en-us/archive/msdn-magazine/2002/december/sending-files-attachments-and-soap-messages-via-dime
+  - https://learn.microsoft.com/en-us/archive/msdn-magazine/2002/december/sending-files-attachments-and-soap-messages-via-dime
   - http://imrannazar.com/Parsing-the-DIME-Message-Format
 seq:
   - id: records

--- a/network/microsoft_network_monitor_v2.ksy
+++ b/network/microsoft_network_monitor_v2.ksy
@@ -20,7 +20,7 @@ doc: |
 
   There are at least 2 different versions of the format: v1 and
   v2. Netmon v3 seems to use the same file format as v1.
-doc-ref: https://docs.microsoft.com/en-us/windows/win32/netmon2/capturefile-header-values
+doc-ref: https://learn.microsoft.com/en-us/windows/win32/netmon2/capturefile-header-values
 seq:
   - id: signature
     contents: GMBU
@@ -92,7 +92,7 @@ types:
       A container for actually captured network data. Allow to
       timestamp individual frames and designates how much data from
       the original packet was actually written into the file.
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/netmon2/frame
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/netmon2/frame
     seq:
       - id: ts_delta
         type: u8

--- a/serialization/asn1/asn1_der.ksy
+++ b/serialization/asn1/asn1_der.ksy
@@ -87,7 +87,7 @@ types:
         encoding: ASCII # actually a subset of ASCII
   body_object_id:
     -webide-representation: '{first:dec}.{second:dec}.{rest}'
-    doc-ref: https://docs.microsoft.com/en-us/windows/desktop/SecCertEnroll/about-object-identifier
+    doc-ref: https://learn.microsoft.com/en-us/windows/desktop/SecCertEnroll/about-object-identifier
     seq:
       - id: first_and_second
         type: u1

--- a/serialization/ruby_marshal.ksy
+++ b/serialization/ruby_marshal.ksy
@@ -15,7 +15,7 @@ doc: |
   * Java's
     [Serializable](https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html)
   * .NET
-    [BinaryFormatter](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter)
+    [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter)
   * Python's
     [marshal](https://docs.python.org/3/library/marshal.html),
     [pickle](https://docs.python.org/3/library/pickle.html) and

--- a/windows/windows_minidump.ksy
+++ b/windows/windows_minidump.ksy
@@ -12,7 +12,7 @@ doc: |
 
   The file itself is a container, which contains a number of typed
   "streams", which contain some data according to its type attribute.
-doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_header
+doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_header
 # https://github.com/libyal/libmdmp/blob/master/documentation/Minidump%20(MDMP)%20format.asciidoc
 seq:
   - id: magic1
@@ -47,7 +47,7 @@ instances:
 types:
   dir:
     -orig-id: MINIDUMP_DIRECTORY
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_directory
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_directory
     seq:
       - id: stream_type
         -orig-id: StreamType
@@ -56,7 +56,7 @@ types:
       - id: len_data
         -orig-id: DataSize
         type: u4
-        doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_location_descriptor
+        doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_location_descriptor
       - id: ofs_data
         type: u4
         -orig-id: Rva
@@ -77,7 +77,7 @@ types:
     doc: |
       "System info" stream provides basic information about the
       hardware and operating system which produces this dump.
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_system_info
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_system_info
     seq:
       - id: cpu_arch
         -orig-id: ProcessorArchitecture
@@ -129,8 +129,8 @@ types:
         9: amd64
         0xffff: unknown
   misc_info:
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_misc_info
-    # https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_misc_info_2
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_misc_info
+    # https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_misc_info_2
     seq:
       - id: len_info
         -orig-id: SizeOfInfo
@@ -167,7 +167,7 @@ types:
         type: u4
   thread_list:
     -orig-id: MINIDUMP_THREAD_LIST
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_thread_list
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_thread_list
     seq:
       - id: num_threads
         -orig-id: NumberOfThreads
@@ -179,7 +179,7 @@ types:
         repeat-expr: num_threads
   thread:
     -orig-id: MINIDUMP_THREAD
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_thread
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_thread
     seq:
       - id: thread_id
         -orig-id: ThreadId
@@ -205,7 +205,7 @@ types:
         type: location_descriptor
   memory_list:
     -orig-id: MINIDUMP_MEMORY_LIST
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory64_list
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory64_list
     seq:
       - id: num_mem_ranges
         type: u4
@@ -215,7 +215,7 @@ types:
         repeat-expr: num_mem_ranges
   exception_stream:
     -orig-id: MINIDUMP_EXCEPTION_STREAM
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_exception_stream
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_exception_stream
     seq:
       - id: thread_id
         -orig-id: ThreadId
@@ -231,7 +231,7 @@ types:
         type: location_descriptor
   exception_record:
     -orig-id: MINIDUMP_EXCEPTION
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_exception
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_exception
     seq:
       - id: code
         -orig-id: ExceptionCode
@@ -266,7 +266,7 @@ types:
           15), but in reality only first `num_params` would be used.
   memory_descriptor:
     -orig-id: MINIDUMP_MEMORY_DESCRIPTOR
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory_descriptor
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory_descriptor
     seq:
       - id: addr_memory_range
         -orig-id: StartOfMemoryRange
@@ -275,7 +275,7 @@ types:
         type: location_descriptor
   location_descriptor:
     -orig-id: MINIDUMP_LOCATION_DESCRIPTOR
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_location_descriptor
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_location_descriptor
     seq:
       - id: len_data
         -orig-id: DataSize
@@ -292,7 +292,7 @@ types:
     doc: |
       Specific string serialization scheme used in MiniDump format is
       actually a simple 32-bit length-prefixed UTF-16 string.
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_string
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_string
     seq:
       - id: len_str
         -orig-id: Length
@@ -304,7 +304,7 @@ types:
         encoding: UTF-16LE
 enums:
   stream_types:
-    # https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ne-minidumpapiset-minidump_stream_type
+    # https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ne-minidumpapiset-minidump_stream_type
     0: unused
     1: reserved_0
     2: reserved_1

--- a/windows/windows_resource_file.ksy
+++ b/windows/windows_resource_file.ksy
@@ -42,7 +42,7 @@ types:
       Each resource has a `type` and a `name`, which can be used to
       identify it, and a `value`. Both `type` and `name` can be a
       number or a string.
-    doc-ref: https://docs.microsoft.com/en-us/windows/win32/menurc/resourceheader
+    doc-ref: https://learn.microsoft.com/en-us/windows/win32/menurc/resourceheader
     seq:
       - id: value_size
         -orig-id: DataSize
@@ -95,7 +95,7 @@ types:
           it as enum value, if applicable.
     enums:
       predef_types:
-        # https://docs.microsoft.com/en-us/windows/win32/menurc/resource-types
+        # https://learn.microsoft.com/en-us/windows/win32/menurc/resource-types
         # Win16
         1: cursor
         2: bitmap

--- a/windows/windows_systemtime.ksy
+++ b/windows/windows_systemtime.ksy
@@ -6,7 +6,7 @@ meta:
 doc: |
   Microsoft Windows SYSTEMTIME structure, stores individual components
   of date and time as individual fields, up to millisecond precision.
-doc-ref: https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-systemtime
+doc-ref: https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-systemtime
 seq:
   - id: year
     -orig-id: wYear


### PR DESCRIPTION
Microsoft now redirects `docs.microsoft.com` there and can eventually retire the old domain somewhen.