### PR TITLE
add Portable Image Format (pif)

### DIFF
--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -14,7 +14,7 @@ seq:
   - id: color_table
     size: information_header.len_color_table
   - id: data
-    size: header.len_file - header._sizeof - information_header._sizeof - information_header.len_color_table
+    size: header.len_image
 types:
   header:
     seq:

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -2,11 +2,21 @@ meta:
   id: pif
   title: Portable Image Format
   file-extension: pif
+  xref:
+    justsolve: PIF_(Portable_Image_Format)
   license: LGPL-2.1
   ks-version: 0.9
   endian: le
   bit-endian: le
-doc-ref: https://github.com/gfcwfzkm/PIF-Image-Format/blob/cc256d5/Specification/PIF%20Format%20Specification.pdf
+doc: |
+  The Portable Image Format (PIF) is a basic, bitmap-like image format with the
+  focus on ease of use (implementation) and small size for embedded
+  applications.
+
+  See <https://github.com/gfcwfzkm/PIF-Image-Format> for more info.
+doc-ref:
+  - https://github.com/gfcwfzkm/PIF-Image-Format/blob/cc256d5/Specification/PIF%20Format%20Specification.pdf
+  - https://github.com/gfcwfzkm/PIF-Image-Format/blob/cc256d5/C%20Library/pifdec.c#L300
 seq:
   - id: file_header
     type: pif_header

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -39,13 +39,17 @@ types:
         type: u4
       - id: len_color_table
         type: u2
-      - id: compressed
+      - id: compression
         type: u2
+        enum: compression_type
         valid:
-          any-of: [0, 0x7dde]
-    instances:
-      is_compressed:
-        value: compressed == 0x7dde
+          any-of:
+            - compression_type::none
+            - compression_type::rle
+    enums:
+      compression_type:
+        0: none
+        0x7dde: rle
 enums:
   image_type:
     0x433c: rgb888

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -51,8 +51,23 @@ enums:
     0x433c: rgb888
     0xe5c5: rgb565
     0x1e53: rgb332
-    0xb895: rgb16c
-    0x7daa: black_white
+    0xb895:
+      id: rgb16c
+      doc: |
+        Formula to convert the 4-bit color value in RGB16C mode to RGB values
+        (each in the range from 0 to 255):
+
+        ```
+        red   = 170 * ((color_value & 0b0100) >> 2) + 85 * ((color_value & 0b1000) >> 3)
+        green = 170 * ((color_value & 0b0010) >> 1) + 85 * ((color_value & 0b1000) >> 3)
+        blue  = 170 * ((color_value & 0b0001) >> 0) + 85 * ((color_value & 0b1000) >> 3)
+        ```
+
+        See also <https://en.wikipedia.org/wiki/Color_Graphics_Adapter#Color_palette>
+    0x7daa:
+      id: black_white
+      doc: '0: black, 1: white'
+      doc-ref: https://github.com/gfcwfzkm/PIF-Image-Format/blob/cc256d5/C%20Library/pifdec.c#L233
     0x4952: indexed_rgb888
     0x4947: indexed_rgb565
     0x4942: indexed_rgb332

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -13,8 +13,8 @@ seq:
     type: information_header
   - id: color_table
     size: information_header.len_color_table
-  - id: data
-    size: information_header.len_image
+  - id: image_data
+    size: information_header.len_image_data
 types:
   header:
     seq:
@@ -22,7 +22,7 @@ types:
         contents: ["PIF", 0x00]
       - id: len_file
         type: u4
-      - id: ofs_pixel_array
+      - id: ofs_image_data
         type: u4
   information_header:
     seq:
@@ -35,7 +35,7 @@ types:
         type: u2
       - id: height
         type: u2
-      - id: len_image
+      - id: len_image_data
         type: u4
       - id: len_color_table
         type: u2

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -57,6 +57,6 @@ enums:
     0x1e53: rgb332
     0xb895: rgb16c
     0x7daa: black_white
-    0x4952: indexed_24
-    0x4947: indexed_16
-    0x4942: indexed_8
+    0x4952: indexed_rgb888
+    0x4947: indexed_rgb565
+    0x4942: indexed_rgb332

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -37,6 +37,8 @@ types:
         contents: ["PIF", 0x00]
       - id: len_file
         type: u4
+        valid:
+          min: ofs_image_data_min
       - id: ofs_image_data
         type: u4
         valid:

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -5,7 +5,7 @@ meta:
   license: LGPL-2.1
   ks-version: 0.10
   endian: le
-doc-ref: https://raw.githubusercontent.com/gfcwfzkm/PIF-Image-Format/main/Specification/PIF%20Format%20Specification.pdf
+doc-ref: https://github.com/gfcwfzkm/PIF-Image-Format/blob/cc256d5/Specification/PIF%20Format%20Specification.pdf
 seq:
   - id: header
     type: header

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -3,7 +3,7 @@ meta:
   title: Portable Image Format
   file-extension: pif
   license: LGPL-2.1
-  ks-version: 0.10
+  ks-version: 0.9
   endian: le
 doc-ref: https://github.com/gfcwfzkm/PIF-Image-Format/blob/cc256d5/Specification/PIF%20Format%20Specification.pdf
 seq:

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -1,0 +1,58 @@
+meta:
+  id: pif
+  title: Portable Image Format
+  file-extension: pif
+  license: LGPL-2.1
+  ks-version: 0.10
+  endian: le
+doc-ref: https://raw.githubusercontent.com/gfcwfzkm/PIF-Image-Format/main/Specification/PIF%20Format%20Specification.pdf
+seq:
+  - id: header
+    type: header
+  - id: information_header
+    type: information_header
+  - id: color_table
+    size: information_header.len_color_table
+  - id: data
+    size: header.len_file - header._sizeof - information_header._sizeof - information_header.len_color_table
+types:
+  header:
+    seq:
+      - id: signature
+        contents: ["PIF", 0x00]
+      - id: len_file
+        type: u4
+      - id: ofs_pixel_array
+        type: u4
+  information_header:
+    seq:
+      - id: image_type
+        type: u2
+        enum: image_type
+      - id: bits_per_pixel
+        type: u2
+      - id: width
+        type: u2
+      - id: height
+        type: u2
+      - id: len_image
+        type: u4
+      - id: len_color_table
+        type: u2
+      - id: compressed
+        type: u2
+        valid:
+          any-of: [0, 0x7dde]
+    instances:
+      is_compressed:
+        value: compressed == 0x7dde
+enums:
+  image_type:
+    0x433c: rgb888
+    0xe5c5: rgb565
+    0x1e53: rgb332
+    0xb895: rgb16c
+    0x7daa: black_white
+    0x4952: indexed_24
+    0x4947: indexed_16
+    0x4942: indexed_8

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -14,7 +14,7 @@ seq:
   - id: color_table
     size: information_header.len_color_table
   - id: data
-    size: header.len_image
+    size: information_header.len_image
 types:
   header:
     seq:

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -18,7 +18,7 @@ seq:
 types:
   header:
     seq:
-      - id: signature
+      - id: magic
         contents: ["PIF", 0x00]
       - id: len_file
         type: u4

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -46,10 +46,6 @@ types:
           any-of:
             - compression_type::none
             - compression_type::rle
-    enums:
-      compression_type:
-        0: none
-        0x7dde: rle
 enums:
   image_type:
     0x433c: rgb888
@@ -60,3 +56,6 @@ enums:
     0x4952: indexed_rgb888
     0x4947: indexed_rgb565
     0x4942: indexed_rgb332
+  compression_type:
+    0x0000: none
+    0x7dde: rle

--- a/image/pif.ksy
+++ b/image/pif.ksy
@@ -7,16 +7,16 @@ meta:
   endian: le
 doc-ref: https://github.com/gfcwfzkm/PIF-Image-Format/blob/cc256d5/Specification/PIF%20Format%20Specification.pdf
 seq:
-  - id: header
-    type: header
-  - id: information_header
+  - id: file_header
+    type: pif_header
+  - id: info_header
     type: information_header
   - id: color_table
-    size: information_header.len_color_table
+    size: info_header.len_color_table
   - id: image_data
-    size: information_header.len_image_data
+    size: info_header.len_image_data
 types:
-  header:
+  pif_header:
     seq:
       - id: magic
         contents: ["PIF", 0x00]


### PR DESCRIPTION
This PR adds a fairly basic specification of the PIF format, a fairly new image format for embedded systems and microcontrollers: https://hackaday.com/2022/05/08/creating-an-image-format-for-embedded-hardware/