### PR TITLE
add grammar for ResPack.cfg

### DIFF
--- a/archive/respack.ksy
+++ b/archive/respack.ksy
@@ -1,0 +1,28 @@
+meta:
+  id: respack
+  title: respack
+  license: CC0-1.0
+  encoding: UTF-8
+  endian: le
+doc: |
+  Resources file found in CPB firmware archives, mostly used on older CoolPad
+  phones and/or tablets. The only observed files are called "ResPack.cfg".
+seq:
+  - id: header
+    type: header
+  - id: json
+    size: header.len_json
+    type: strz
+types:
+  header:
+    seq:
+      - id: magic
+        contents: "RS"
+      - id: unknown
+        size: 8
+      - id: len_json
+        type: u4
+      - id: md5
+        size: 32
+        type: str
+        doc: MD5 of data that follows the header


### PR DESCRIPTION
This PR adds a simple grammar for `ResPack.cfg` files, which can be found on older Android phones/tablets made by Coolpad. Example files can be found in the firmware of for example the `7295C-C00` but you can also find some examples on vague websites by searching for `ResPack.cfg`.

The format itself is fairly simple: a header containing some magic, then some unknown bytes, a length field describing the length of some embedded JSON, and the MD5 for everything following the header.

Then there is some JSON containing the names, offsets (relative to the end of the JSON) and length of individual files (such as PNGs and other resources) and finally the data of the files.

The grammar in this PR does not parse the contents of the JSON, which should probably be done outside of KS.