### PR TITLE
fix string condition

### DIFF
--- a/database/sqlite3.ksy
+++ b/database/sqlite3.ksy
@@ -230,6 +230,7 @@ types:
         type: str
         size: serial_type.len_content
         encoding: UTF-8
+        if: serial_type.is_string
 #        if: _root.text_encoding == encodings::utf_8 and serial_type.is_string
     instances:
       serial_type:


### PR DESCRIPTION
the parser was trying to decode non-string fields as string

```
import parser.sqlite3 as parser_sqlite3
db = parser_sqlite3.Sqlite3.from_file("test.db")
cell = db.root_page.cells[0]
print(cell.body)
```

error was

```
Traceback (most recent call last):
  File "parse.py", line 9, in <module>
    cell.body
  File "parser/sqlite3.py", line 337, in body
    self._m_body = Sqlite3.CellTableLeaf(self._io, self, self._root)
  File "parser/sqlite3.py", line 191, in __init__
    self._read()
  File "parser/sqlite3.py", line 198, in _read
    self.payload = Sqlite3.CellPayload(_io__raw_payload, self, self._root)
  File "parser/sqlite3.py", line 210, in __init__
    self._read()
  File "parser/sqlite3.py", line 224, in _read
    Sqlite3.ColumnContent(
  File "parser/sqlite3.py", line 270, in __init__
    self._read()
  File "parser/sqlite3.py", line 297, in _read
    self.as_str = (self._io.read_bytes(self.serial_type.len_content)).decode(
  File "parser/kaitaistruct.py", line 302, in read_bytes
    if n < 0:
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```
