### PR TITLE
rockchip specific logo container format

### DIFF
--- a/image/rockchip_rkel.ksy
+++ b/image/rockchip_rkel.ksy
@@ -54,13 +54,13 @@ types:
         type: u2
       - id: width
         type: u2
-      - id: unknown_3
+      - id: unknown_2
         type: u4
       - id: ofs_image_data
         type: u4
       - id: len_image_data
         type: u4
-      - id: unknown_4
+      - id: unknown_3
         size: 8
     instances:
       image_data:

--- a/image/rockchip_rkel.ksy
+++ b/image/rockchip_rkel.ksy
@@ -1,0 +1,69 @@
+meta:
+  id: rkel
+  title: Rockchip RKEL
+  license: CC0
+  endian: le
+  encoding: UTF-8
+doc: |
+  Image format found in devices with the Rockchip RK3566, such as the PineNote
+  <https://wiki.pine64.org/wiki/PineNote>
+
+  Example files:
+
+  <https://github.com/BPI-SINOVOIP/BPI-Rockchip-Android11/tree/master/device/rockchip/rk356x/rk3566_eink/ota>
+seq:
+  - id: header
+    size: 64
+    type: header
+  - id: data
+    size: header.len_data - header._sizeof
+    type: images(header.num_images)
+types:
+  header:
+    seq:
+      - id: magic
+        contents: "RKEL"
+      - id: len_data
+        type: u4
+      - id: height
+        type: u4
+      - id: width
+        type: u4
+      - id: num_images
+        type: u4
+      - id: version
+        type: strz
+        size-eos: true
+  images:
+    params:
+      - id: num_images
+        type: u4
+    seq:
+      - id: image_entries
+        size: 32
+        type: image_entry
+        repeat: expr
+        repeat-expr: num_images
+  image_entry:
+    seq:
+      - id: signature
+        contents: ['GR04']
+      - id: unknown_1
+        type: u4
+      - id: height
+        type: u2
+      - id: width
+        type: u2
+      - id: unknown_3
+        type: u4
+      - id: ofs_image_data
+        type: u4
+      - id: len_image_data
+        type: u4
+      - id: unknown_4
+        size: 8
+    instances:
+      image_data:
+        pos: ofs_image_data
+        size: len_image_data
+        io: _root._io


### PR DESCRIPTION
This PR adds a spec for a format used by Rockchip on at least some of their eInk devices. I could not find any specification about what the fields are whatsoever, but it seems to be fairly simple (`height` and `width` are quite obvious when searching for the particular chipset). My guess is that what I am calling `unknown_2` is probably a setting for the image quality and `unknown_3` could perhaps be X/Y coordinates.

The data itself: possibly something raw or BMPs without a header (which is not uncommon on Android).