### PR TITLE
add specification for Instar BNEG files

### DIFF
--- a/firmware/instar_bneg.ksy
+++ b/firmware/instar_bneg.ksy
@@ -1,0 +1,34 @@
+meta:
+  id: instar_bneg
+  title: Instar BNEG
+  license: MIT
+  endian: le
+  encoding: ASCII
+doc: |
+  An old uClinux based firmware format for IP cameras. Test files:
+  - https://wiki.instar.com/en/Downloads/Outdoor_Cameras/IN-2905_V2/
+doc-ref:
+  - https://web.archive.org/web/20160404193454/http://wiki.openipcam.com/index.php/Firmware_Structure
+  - https://github.com/onekey-sec/unblob/blob/5d9fd6d8/unblob/handlers/archive/instar/bneg.py
+seq:
+  - id: header
+    type: header
+  - id: kernel
+    size: header.len_kernel
+  - id: rootfs
+    size: header.len_rootfs
+types:
+  header:
+    seq:
+      - id: magic
+        contents: 'BNEG'
+      - id: major
+        type: u4
+        valid: 1
+      - id: minor
+        type: u4
+        valid: 1
+      - id: len_kernel
+        type: u4
+      - id: len_rootfs
+        type: u4


### PR DESCRIPTION
This PR adds a specification for the BNEG format used by Instar (and possibly others, but I couldn't find it). It is an extremely simple format with a header, major/minor version and a few lengths. The format is old as it is for uClinux based IP cameras, so mostly added for completeness.