### PR TITLE
Change the type of timeval.sec of log/glibc_utmp.ksy to follow the change of GNU libc

### DIFF
--- a/log/glibc_utmp.ksy
+++ b/log/glibc_utmp.ksy
@@ -60,7 +60,7 @@ types:
   timeval:
     seq:
       - id: sec
-        type: s4
+        type: u4
         doc: Seconds
       - id: usec
         type: s4


### PR DESCRIPTION
The type of tv_sec in bits/utmp.h of GNU libc was changed from int32_t to __uint32_t on 19 April 2024 to address the year 2038 problem.

The relevant commit of GNU libc:
https://sourceware.org/git/?p=glibc.git;a=commit;h=5361ad3910c257bc327567be76fde532ed238e42
