### PR TITLE
Correct the type of pid of log/glibc_utmp.ksy to match the definition in GNU libc

### DIFF
--- a/log/glibc_utmp.ksy
+++ b/log/glibc_utmp.ksy
@@ -21,7 +21,7 @@ types:
         doc: Type of login
         enum: entry_type
       - id: pid
-        type: u4
+        type: s4
         doc: Process ID of login process
       - id: line
         type: str


### PR DESCRIPTION
utmp.h of GNU libc defines the type of ut_pid as pid_t (signed int). The current definition of pid in the glibc_utmp.ksy is u4 (unsigned int). This commit corrects the type of pid to s4 (signed int).

The relevant definitions in GNU libc:
ut_pid is defined as pid_t
https://sourceware.org/git/?p=glibc.git;a=blob;f=bits/utmp.h;h=d9a166e8d685af5c3603d1e0d64d08786d5a42ed;hb=HEAD

__PID_T_TYPE is defined as __S32_TYPE
https://sourceware.org/git/?p=glibc.git;a=blob;f=bits/typesizes.h;h=b6db5c3637702a760f8318881342f7c327ed3fe0;hb=HEAD
