### PR TITLE
Fix typos (mostly) found by codespell

### DIFF
--- a/archive/phar_without_stub.ksy
+++ b/archive/phar_without_stub.ksy
@@ -219,7 +219,7 @@ types:
         SHA-512 signature types.
       * 1.1.1: Supported since phar extension 2.0.0 (released 2009-07-29 and
         included with PHP 5.3 and later). (PHP_Archive 0.12.0 also supports
-        all features from API verison 1.1.1, but it reports API version 1.1.0.)
+        all features from API version 1.1.1, but it reports API version 1.1.0.)
         Adds the OpenSSL signature type and support for storing
         empty directories.
     seq:

--- a/archive/rpm.ksy
+++ b/archive/rpm.ksy
@@ -495,7 +495,7 @@ enums:
       -orig-id: RPMTAG_DESCRIPTION
       doc: |
         Specifies the description of the package. The description value
-        pointed to by this index record contains a full desription of
+        pointed to by this index record contains a full description of
         the package.
     1006:
       id: build_time
@@ -770,7 +770,7 @@ enums:
     1082:
       id: changelog_text
       -orig-id: RPMTAG_CHANGELOGTEXT
-      doc: Specifies the changes asssociated with a changelog entry.
+      doc: Specifies the changes associated with a changelog entry.
     1083:
       id: broken_md5_internal
       -orig-id: RPMTAG_BROKENMD5
@@ -789,7 +789,7 @@ enums:
       -orig-id: RPMTAG_POSTINPROG
       doc: |
         Specifies the name of the interpreter to which the postinstall
-        scriptlet will be passed. The intepreter pointed to by this
+        scriptlet will be passed. The interpreter pointed to by this
         index record shall be `/bin/sh`.
     1087:
       id: pre_uninstall_interpreter

--- a/common/utf8_string.ksy
+++ b/common/utf8_string.ksy
@@ -12,7 +12,7 @@ doc: |
 
   * variable width (i.e. one code point might be represented by 1 to 4
     bytes)
-  * backward compatiblity with ASCII
+  * backward compatibility with ASCII
   * basic validity checking (and thus distinguishing from other legacy
     8-bit encodings)
   * maintaining sort order of codepoints if sorted as a byte array

--- a/executable/elf.ksy
+++ b/executable/elf.ksy
@@ -1895,7 +1895,7 @@ enums:
         specific, and should have been in the range DT_LOPROC-DT_HIPROC
         instead of here. When the error was fixed,
         DT_DEPRECATED_SPARC_REGISTER was created to maintain backward
-        compatability.
+        compatibility.
       doc-ref:
         - https://github.com/illumos/illumos-gate/blob/1d806c5f41/usr/src/cmd/sgs/libconv/common/dynamic.c#L522-L528
         - https://github.com/illumos/illumos-gate/blob/1d806c5f41/usr/src/boot/sys/sys/elf_common.h#L634-L635

--- a/executable/mach_o.ksy
+++ b/executable/mach_o.ksy
@@ -138,10 +138,10 @@ types:
         doc: "the object file has no undefined references"
       incr_link:
         value: value & 0x2 != 0
-        doc: "the object file is the output of an incremental link against a base file and can't be link edited again"
+        doc: "the object file is the output of an incremental link against a base file and can't be link-edited again"
       dyld_link:
         value: value & 0x4 != 0
-        doc: "the object file is input for the dynamic linker and can't be staticly link edited again"
+        doc: "the object file is input for the dynamic linker and can't be statically link-edited again"
       bind_at_load:
         value: value & 0x8 != 0
         doc: "the object file's undefined references are bound by the dynamic linker when loaded."
@@ -162,7 +162,7 @@ types:
         doc: "the executable is forcing all images to use flat name space bindings"
       no_multi_defs:
         value: value & 0x200 != 0
-        doc: "this umbrella guarantees no multiple defintions of symbols in its sub-images so the two-level namespace hints can always be used."
+        doc: "this umbrella guarantees no multiple definitions of symbols in its sub-images so the two-level namespace hints can always be used."
       no_fix_prebinding:
         value: value & 0x400 != 0
         doc: "do not have dyld notify the prebinding agent about this executable"

--- a/filesystem/vdi.ksy
+++ b/filesystem/vdi.ksy
@@ -185,7 +185,7 @@ types:
               - id: sector_size
                 type: u4
           flags:
-            seq: #little endian assummed
+            seq: #little endian assumed
               - id: reserved0
                 type: b15
               - id: zero_expand

--- a/filesystem/vfat.ksy
+++ b/filesystem/vfat.ksy
@@ -234,7 +234,7 @@ types:
           Logical sector number of FS Information Sector, typically 1,
           i.e., the second of the three FAT32 boot sectors. Values
           like 0 and 0xFFFF are used by some FAT32 implementations to
-          designate abscence of FS Information Sector.
+          designate absence of FS Information Sector.
       - id: boot_sectors_copy_start_ls
         type: u2
         doc: |

--- a/font/pcf_font.ksy
+++ b/font/pcf_font.ksy
@@ -103,7 +103,7 @@ types:
             doc: |
               Property is a key-value pair, "key" being always a
               string and "value" being either a string or a 32-bit
-              integer based on an additinal flag (`is_string`).
+              integer based on an additional flag (`is_string`).
 
               Simple offset-based mechanism is employed to keep this
               type's sequence fixed-sized and thus have simple access

--- a/image/bmp.ksy
+++ b/image/bmp.ksy
@@ -64,7 +64,7 @@ doc: |
   the documentation on MSDN has probably got lost and they have probably
   forgotten about this type of header.
 
-  This is the only source I could find about these structures, so we could't rely
+  This is the only source I could find about these structures, so we couldn't rely
   on it so much, but I think supporting them as a read-only format won't harm anything.
   Due to the fact that it isn't documented anywhere else, most applications don't support it.
 
@@ -432,7 +432,7 @@ types:
         type: bool
       - id: num_colors
         doc: |
-          If equal to 0, the pallete should contain as many colors as can fit into the pixel value
+          If equal to 0, the palette should contain as many colors as can fit into the pixel value
           according to the `bits_per_pixel` field (if `bits_per_pixel` = 8, then the pixel can
           represent 2 ** 8 = 256 values, so exactly 256 colors should be present). For more flexibility,
           it reads as many colors as it can until EOS is reached (and the image data begin).

--- a/image/jpeg.ksy
+++ b/image/jpeg.ksy
@@ -31,7 +31,7 @@ doc: |
 
   Format is organized as a container format, serving multiple
   "segments", each starting with a magic and a marker. JFIF standard
-  dictates order and mandatory apperance of segments:
+  dictates order and mandatory appearance of segments:
 
   * SOI
   * APP0 (with JFIF magic)

--- a/log/windows_evt_log.ksy
+++ b/log/windows_evt_log.ksy
@@ -105,7 +105,7 @@ types:
           - id: wrap
             -orig-id: ELF_LOGFILE_HEADER_WRAP
             type: b1
-            doc: True if wrapping of record has occured.
+            doc: True if wrapping of record has occurred.
           - id: dirty
             -orig-id: ELF_LOGFILE_HEADER_DIRTY
             type: b1
@@ -154,7 +154,7 @@ types:
       - id: time_written
         -orig-id: TimeWritten
         type: u4
-        doc: Time when thsi record was written into the log file, POSIX timestamp format.
+        doc: Time when this record was written into the log file, POSIX timestamp format.
       - id: event_id
         -orig-id: EventID
         type: u4

--- a/media/id3v1_1.ksy
+++ b/media/id3v1_1.ksy
@@ -51,7 +51,7 @@ types:
         doc: Year of release
       - id: comment
         size: 30
-        doc: Arbitary comment
+        doc: Arbitrary comment
       - id: genre
         type: u1
         enum: genre_enum
@@ -124,7 +124,7 @@ types:
         64: native_american
         65: cabaret
         66: new_wave
-        67: psychadelic
+        67: psychedelic
         68: rave
         69: showtunes
         70: trailer

--- a/network/bitcoin_transaction.ksy
+++ b/network/bitcoin_transaction.ksy
@@ -44,7 +44,7 @@ types:
       - id: output_id
         type: u4
         doc: |
-          ID indexing an ouput of the transaction refered by txid.
+          ID indexing an output of the transaction referred by txid.
           This output will be used as an input in the present transaction.
       - id: len_script
         type: u1
@@ -137,7 +137,7 @@ types:
       - id: amount
         type: u8
         doc: |
-          Number of Satoshis to be transfered.
+          Number of Satoshis to be transferred.
       - id: len_script
         type: u1
         doc: |

--- a/network/dns_packet.ksy
+++ b/network/dns_packet.ksy
@@ -11,7 +11,7 @@ doc: |
   (No support for Auth-Name + Add-Name for simplicity)
 seq:
   - id: transaction_id
-    doc: "ID to keep track of request/responces"
+    doc: "ID to keep track of request/responses"
     type: u2
   - id: flags
     type: packet_flags
@@ -186,7 +186,7 @@ types:
     seq:
       - id: primary_ns
         type: domain_name
-      - id: resoponsible_mailbox
+      - id: responsible_mailbox
         type: domain_name
       - id: serial
         type: u4

--- a/network/ethernet_frame.ksy
+++ b/network/ethernet_frame.ksy
@@ -44,7 +44,7 @@ instances:
     value: |
       (ether_type_1 == ether_type_enum::ieee_802_1q_tpid) ? ether_type_2 : ether_type_1
     doc: |
-      Ether type can be specied in several places in the frame. If
+      Ether type can be specified in several places in the frame. If
       first location bears special marker (0x8100), then it is not the
       real ether frame yet, an additional payload (`tci`) is expected
       and real ether type is upcoming next.

--- a/network/icmp_packet.ksy
+++ b/network/icmp_packet.ksy
@@ -43,8 +43,8 @@ types:
         3: port_unreachable
         4: fragmentation_needed_and_df_set
         5: source_route_failed
-        6: dst_net_unkown
-        7: sdt_host_unkown
+        6: dst_net_unknown
+        7: sdt_host_unknown
         8: src_isolated
         9: net_prohibited_by_admin
         10: host_prohibited_by_admin

--- a/network/some_ip/some_ip.ksy
+++ b/network/some_ip/some_ip.ksy
@@ -123,7 +123,7 @@ types:
     instances:
       is_valid_service_discovery:
         value: message_id.value == 0xffff8100 and protocol_version == 0x01 and interface_version == 0x01 and message_type == message_type_enum::notification and return_code == return_code_enum::ok
-        doc: auxillary value
+        doc: auxiliary value
         doc-ref: AUTOSAR_PRS_SOMEIPServiceDiscoveryProtocol.pdf - section 4.1.2.1 General Requirements
 
     enums:

--- a/security/ssh_public_key.ksy
+++ b/security/ssh_public_key.ksy
@@ -6,7 +6,7 @@ meta:
 doc: |
   SSH public keys are encoded in a special binary format, typically represented
   to end users as either one-liner OpenSSH format or multi-line PEM format
-  (commerical SSH). Text wrapper carries extra information about user who
+  (commercial SSH). Text wrapper carries extra information about user who
   created the key, comment, etc, but the inner binary is always base64-encoded
   and follows the same internal format.
 

--- a/serialization/google_protobuf.ksy
+++ b/serialization/google_protobuf.ksy
@@ -57,8 +57,8 @@ types:
           Value that corresponds to field identified by
           `field_tag`. Type is determined approximately: there is
           enough information to parse it unambiguously from a stream,
-          but further infromation from `.proto` file is required to
-          interprete it properly.
+          but further information from `.proto` file is required to
+          interpret it properly.
         type:
           switch-on: wire_type
           cases:
@@ -73,8 +73,8 @@ types:
         doc: |
           "Wire type" is a part of the "key" that carries enough
           information to parse value from the wire, i.e. read correct
-          amount of bytes, but there's not enough informaton to
-          interprete in unambiguously. For example, one can't clearly
+          amount of bytes, but there's not enough information to
+          interpret in unambiguously. For example, one can't clearly
           distinguish 64-bit fixed-sized integers from 64-bit floats,
           signed zigzag-encoded varints from regular unsigned varints,
           arbitrary bytes from UTF-8 encoded strings, etc.

--- a/serialization/python_pickle.ksy
+++ b/serialization/python_pickle.ksy
@@ -285,7 +285,7 @@ types:
     doc: |
       Length prefixed string, between 0 and 2**64-1 bytes long.
 
-      The contents are deserilised into a `bytearray` object.
+      The contents are deserialised into a `bytearray` object.
     seq:
       - id: len
         type: u8

--- a/serialization/python_pickle.ksy
+++ b/serialization/python_pickle.ksy
@@ -142,7 +142,7 @@ types:
         terminator: 0x0a # "\n"
 
   decimalnl_long:
-    doc: Integer, encoded with the ASCII chracters [0-9-], followed by 'L'.
+    doc: Integer, encoded with the ASCII characters [0-9-], followed by 'L'.
     seq:
       - id: val
         type: str
@@ -225,8 +225,8 @@ types:
       Instead, opcodes and types with a known encoding are used.
       When unpickling
 
-      - `pickle.Unpickler` objects default to ASCII, which can be overriden
-      - `pickletools.dis` uses latin1, and cannot be overriden
+      - `pickle.Unpickler` objects default to ASCII, which can be overridden
+      - `pickletools.dis` uses latin1, and cannot be overridden
     doc-ref: https://github.com/python/cpython/blob/bb8071a4cae/Lib/pickle.py#L486-L495
     seq:
       - id: len


### PR DESCRIPTION
There are other typos in `id` keys, but I fear that fixing them may break backwards compatibility:

https://github.com/kaitai-io/kaitai_struct_formats/blob/5f37c8178a631ae1d50e044be7af58dced0d0b69/media/id3v1_1.ksy#L127

https://github.com/kaitai-io/kaitai_struct_formats/blob/5f37c8178a631ae1d50e044be7af58dced0d0b69/network/dns_packet.ksy#L189

https://github.com/kaitai-io/kaitai_struct_formats/blob/5f37c8178a631ae1d50e044be7af58dced0d0b69/network/icmp_packet.ksy#L46-L47