### PR TITLE
Fixes for https://github.com/kaitai-io/kaitai_struct_formats/issues/728

### DIFF
--- a/image/nitf.ksy
+++ b/image/nitf.ksy
@@ -297,11 +297,10 @@ types:
         type: image_data_mask
         if: has_mask
       - id: image_data_field
-        if: has_mask
-        size: _parent.header.linfo[idx].length_image_segment.to_i - image_data_mask.total_size
+        size: 'has_mask ? _parent.header.linfo[idx].length_image_segment.to_i - image_data_mask.total_size : _parent.header.linfo[idx].length_image_segment.to_i'
     instances:
       has_mask:
-        value: image_sub_header.img_compression.substring(0, 2) == 'MM'
+        value: image_sub_header.img_compression.substring(0, 1) == 'M' or image_sub_header.img_compression.substring(1, 2) == 'M'
   image_sub_header:
     seq:
       - id: file_part_type
@@ -371,6 +370,7 @@ types:
         -orig-id: igeolo
         type: str
         size: 60
+        if: image_coordinate_rep != ' '
       - id: num_img_comments
         -orig-id: nicom
         type: str
@@ -388,6 +388,7 @@ types:
         -orig-id: comrat
         type: str
         size: 4
+        if: img_compression.substring(0, 1) != 'N'
       - id: num_bands
         -orig-id: nbands
         type: str
@@ -630,11 +631,10 @@ types:
         type: str
         size: 3
         if: header_data_length.to_i != 0
-      - id: header_data
-        type: u1
-        if: header_data_length.to_i > 2
-        repeat: expr
-        repeat-expr: header_data_length.to_i - 3
+      - id: tres
+        type: tre_entries
+        size: header_data_length.to_i - 3
+        if: header_data_length.to_i != 0
   text_segment:
     params:
       - id: idx
@@ -821,3 +821,8 @@ types:
         type: str
         size: edata_length.to_i
         doc: 'REDATA or CEDATA'
+  tre_entries:
+    seq:
+      - id: entries
+        type: tre
+        repeat: eos


### PR DESCRIPTION
Changes have been tested using https://ide.kaitai.io/ with a few sample NITFs from https://earth.esa.int/eogateway/ftp/missions/sample-data/third-party-missions/rapideye/REScene_Basic_Analytic_nitf.zip as well as some proprietary NITFs.

The new TRE array display looks like this...
<img width="822" height="317" alt="image" src="https://github.com/user-attachments/assets/640588b7-cb20-41c8-83a6-2b1a31e44ca5" />

haitai-struct-compiler -all nitf.ksy gives the following warnings...
```
C:/dev/dwelch/kaitai_struct_formats/image/nitf.ksy: /types/image_data_mask/instances/tpxcd_size/id:
        warning: use `len_tpxcd` instead of `tpxcd_size`, given that it's only used as a byte size of `tpxcd` (see https://doc.kaitai.io/ksy_style_guide.html#attr-id)

C:/dev/dwelch/kaitai_struct_formats/image/nitf.ksy: /types/image_data_mask/instances/bmrtmr_count/id:
        warning: use `num_bmrbnd` instead of `bmrtmr_count`, given that it's only used as repeat count of `bmrbnd` (see https://doc.kaitai.io/ksy_style_guide.html#attr-id)

C:/dev/dwelch/kaitai_struct_formats/image/nitf.ksy: /types/image_data_mask/instances/bmrtmr_count/id:
        warning: use `num_tmrbnd` instead of `bmrtmr_count`, given that it's only used as repeat count of `tmrbnd` (see https://doc.kaitai.io/ksy_style_guide.html#attr-id)
```

No attempt was made to address these warnings as they existed prior to the changes in this PR.
