### PR TITLE
Add `_build/Gemfile.lock` for reproducibility and supply chain security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+  - package-ecosystem: bundler
+    directory: /_build
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: '4.0'
+          working-directory: _build  # Used to resolve `Gemfile.lock` and install Bundler accordingly
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'

--- a/_build/.bundle/config
+++ b/_build/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_FROZEN: "true"

--- a/_build/Gemfile
+++ b/_build/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'https://rubygems.org', cooldown: 7
 
 gem 'commonmarker'
 gem 'pygments.rb'

--- a/_build/Gemfile.lock
+++ b/_build/Gemfile.lock
@@ -1,0 +1,40 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    commonmarker (2.8.2-aarch64-linux)
+    commonmarker (2.8.2-aarch64-linux-musl)
+    commonmarker (2.8.2-arm-linux)
+    commonmarker (2.8.2-arm64-darwin)
+    commonmarker (2.8.2-x64-mingw-ucrt)
+    commonmarker (2.8.2-x86_64-darwin)
+    commonmarker (2.8.2-x86_64-linux)
+    commonmarker (2.8.2-x86_64-linux-musl)
+    pygments.rb (4.0.0)
+
+PLATFORMS
+  aarch64-linux
+  aarch64-linux-musl
+  arm-linux
+  arm64-darwin
+  x64-mingw-ucrt
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-musl
+
+DEPENDENCIES
+  commonmarker
+  pygments.rb
+
+CHECKSUMS
+  commonmarker (2.8.2-aarch64-linux) sha256=715a5df28e5c1ec7b520e6441466062e9717b82193d2a5bd11a9c94f2f1e15f0
+  commonmarker (2.8.2-aarch64-linux-musl) sha256=c7d587bd7978416978e84d0de7488906b8f29b3f67ce8424942f0ca9aa6899db
+  commonmarker (2.8.2-arm-linux) sha256=da9da5c08d5133ad429ece13f2e93d3a30e1b23621ffac9040e185d7ea29bde6
+  commonmarker (2.8.2-arm64-darwin) sha256=cd7364f1fb9735d60218e4af0a4afbbeedbc465eb81cccca56f29a4efe2b5013
+  commonmarker (2.8.2-x64-mingw-ucrt) sha256=2c25421e5c2feb59edc7557392410285db881455279d95e9b7b9d5aa0ef3009a
+  commonmarker (2.8.2-x86_64-darwin) sha256=fb946e0bb01f0e5742aef75cc972b51ffe099e5b983ce9cd792b4a78c5d2c297
+  commonmarker (2.8.2-x86_64-linux) sha256=42cfb6532b15dd5821ce99e47397923255f32dcfc81024ef4c17e01e66ac7d75
+  commonmarker (2.8.2-x86_64-linux-musl) sha256=66568dce1c6f265e85d57ea7f749a148446527c7dd599c6ded4cdc819997c43e
+  pygments.rb (4.0.0) sha256=f48bb03a28cf5eaa56e8d3d5a49b76a978199a51bd8643cc4b32fbb7ffecee57
+
+BUNDLED WITH
+  4.0.14


### PR DESCRIPTION
Currently, we only have a [`_build/Gemfile`](https://github.com/kaitai-io/kaitai_struct_formats/blob/1b0392a838ae565ab17bb8ce6bc4e6eb781e4c5c/_build/Gemfile), but no `_build/Gemfile.lock`, so our CI always fetches the latest versions of https://rubygems.org/gems/commonmarker and https://rubygems.org/gems/pygments.rb at any given time. This is not ideal: it means that the installation of gems is not reproducible. We've actually seen this in the past: when [`pygments.rb v2.0.0`](https://github.com/pygments/pygments.rb/releases/tag/v2.0.0) was released, it caused our CI to fail ("on its own"): https://github.com/kaitai-io/kaitai_struct_formats/commit/2856ad9718025594fec9f4b350cf2f2bdd24d8cb#commitcomment-45798747

It's generally recommended to use a lockfile so that the versions are fixed. This also improves supply chain security, see e.g. this article: https://www.fastruby.io/blog/hidden-dangers-in-your-gemfile.html

I'm also enabling Dependabot version updates for Bundler so that we don't stay on outdated versions forever. If a new release of either gem comes out, we'll get a PR to review. Since we have only two RubyGems dependencies, it shouldn't be hard to keep up.