### PR TITLE
png: miscellaneous improvements (mainly in text chunks)

### DIFF
--- a/image/png.ksy
+++ b/image/png.ksy
@@ -257,13 +257,23 @@ types:
       y:
         value: y_int / 100000.0
   gama_chunk:
+    -webide-representation: '{gamma:dec} (= 1/{inv_gamma:dec})'
     doc-ref: https://www.w3.org/TR/png/#11gAMA
     seq:
       - id: gamma_int
         type: u4
+        doc: |
+          Image gamma multiplied by 100000 (a gamma value of 1/2.2 is stored as
+          45455)
     instances:
-      gamma_ratio:
+      gamma:
+        value: gamma_int / 100000.0
+        doc: Image gamma, typically 0.45455 = 1/2.2
+      inv_gamma:
         value: 100000.0 / gamma_int
+        doc: |
+          Inverse of the image gamma (1 / gamma), typically 2.2 (not considering
+          rounding)
   mdcv_chunk:
     doc-ref:
       - https://www.w3.org/TR/png/#mDCV-chunk

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -648,10 +648,14 @@ types:
       - id: dispose_op
         type: u1
         enum: dispose_op_values
+        valid:
+          in-enum: true
         doc: Type of frame area disposal to be done after rendering this frame
       - id: blend_op
         type: u1
         enum: blend_op_values
+        valid:
+          in-enum: true
         doc: Type of frame area rendering for this frame
     instances:
       delay:

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -366,16 +366,27 @@ types:
         type: u1
   international_text_chunk:
     doc: |
-      International text chunk effectively allows to store key-value string pairs in
-      PNG container. Both "key" (keyword) and "value" (text) parts are
-      given in pre-defined subset of ISO-8859-1 without control
-      characters.
+      International textual data (`iTXt`) chunk effectively allows you to store
+      key-value string pairs in the PNG container.
+
+      The "key" part (`keyword`) is restricted to printable ISO-8859-1 (Latin-1)
+      characters and spaces. The translated keyword and the "value" part
+      (`text`) are stored in UTF-8 and thus can store text in any language -
+      this language can be indicated via the language tag (`language_tag`).
     doc-ref: https://www.w3.org/TR/png/#11iTXt
     seq:
       - id: keyword
         type: strz
-        encoding: UTF-8
-        doc: Indicates purpose of the following text data.
+        encoding: ISO-8859-1
+        doc: |
+          Indicates the type of information represented by the text string.
+
+          Keywords must consist exclusively of printable ISO-8859-1 (Latin-1)
+          characters and spaces; that is, only code points 0x20-0x7E and
+          0xA1-0xFF are allowed. To reduce the chances for human misreading of a
+          keyword, leading spaces, trailing spaces, and consecutive spaces are
+          not permitted.
+        doc-ref: https://www.w3.org/TR/2025/REC-png-3-20250624/#11keywords
       - id: compression_flag
         type: u1
         valid:
@@ -430,31 +441,53 @@ types:
           allowed.
   text_chunk:
     doc: |
-      Text chunk effectively allows to store key-value string pairs in
-      PNG container. Both "key" (keyword) and "value" (text) parts are
-      given in pre-defined subset of ISO-8859-1 without control
-      characters.
+      Textual data (`tEXt`) chunk effectively allows you to store key-value
+      string pairs in the PNG container.
+
+      Both the "key" (`keyword`) and "value" (`text`) parts are restricted to
+      printable ISO-8859-1 (Latin-1) characters and ASCII spaces, with the
+      exception that `text` can also contain newlines (U+000A LINE FEED (LF)
+      characters) and U+00A0 NON-BREAKING SPACE characters.
     doc-ref: https://www.w3.org/TR/png/#11tEXt
     seq:
       - id: keyword
         type: strz
         encoding: ISO-8859-1
-        doc: Indicates purpose of the following text data.
+        doc: |
+          Indicates the type of information represented by the text string.
+
+          Keywords must consist exclusively of printable ISO-8859-1 (Latin-1)
+          characters and spaces; that is, only code points 0x20-0x7E and
+          0xA1-0xFF are allowed. To reduce the chances for human misreading of a
+          keyword, leading spaces, trailing spaces, and consecutive spaces are
+          not permitted.
+        doc-ref: https://www.w3.org/TR/2025/REC-png-3-20250624/#11keywords
       - id: text
         type: str
         size-eos: true
         encoding: ISO-8859-1
   compressed_text_chunk:
     doc: |
-      Compressed text chunk effectively allows to store key-value
-      string pairs in PNG container, compressing "value" part (which
-      can be quite lengthy) with zlib compression.
+      Compressed textual data (`zTXt`) chunk effectively allows you to store
+      key-value string pairs in the PNG container, compressing the "value" part
+      (which can be quite lengthy) with zlib compression.
+
+      The `zTXt` and `tEXt` chunks are semantically equivalent, but the `zTXt`
+      chunk is recommended for storing large blocks of text.
     doc-ref: https://www.w3.org/TR/png/#11zTXt
     seq:
       - id: keyword
         type: strz
-        encoding: UTF-8
-        doc: Indicates purpose of the following text data.
+        encoding: ISO-8859-1
+        doc: |
+          Indicates the type of information represented by the text string.
+
+          Keywords must consist exclusively of printable ISO-8859-1 (Latin-1)
+          characters and spaces; that is, only code points 0x20-0x7E and
+          0xA1-0xFF are allowed. To reduce the chances for human misreading of a
+          keyword, leading spaces, trailing spaces, and consecutive spaces are
+          not permitted.
+        doc-ref: https://www.w3.org/TR/2025/REC-png-3-20250624/#11keywords
       - id: compression_method
         type: u1
         enum: compression_methods

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -773,18 +773,21 @@ enums:
   dispose_op_values:
     0:
       id: none
+      -orig-id: APNG_DISPOSE_OP_NONE
       doc: |
         No disposal is done on this frame before rendering the next;
         the contents of the output buffer are left as is.
       doc-ref: https://www.w3.org/TR/png/#fcTL-chunk
     1:
       id: background
+      -orig-id: APNG_DISPOSE_OP_BACKGROUND
       doc: |
         The frame's region of the output buffer is to be cleared to
         fully transparent black before rendering the next frame.
       doc-ref: https://www.w3.org/TR/png/#fcTL-chunk
     2:
       id: previous
+      -orig-id: APNG_DISPOSE_OP_PREVIOUS
       doc: |
         The frame's region of the output buffer is to be reverted
         to the previous contents before rendering the next frame.
@@ -792,12 +795,16 @@ enums:
   blend_op_values:
     0:
       id: source
+      -orig-id: APNG_BLEND_OP_SOURCE
       doc: |
         All color components of the frame, including alpha,
         overwrite the current contents of the frame's output buffer region.
       doc-ref: https://www.w3.org/TR/png/#fcTL-chunk
     1:
       id: over
+      -orig-id: APNG_BLEND_OP_OVER
       doc: |
-        The frame is composited onto the output buffer based on its alpha
+        The frame is composited onto the output buffer based on its alpha, using
+        a simple OVER operation as described in [Alpha Channel
+        Processing](https://www.w3.org/TR/png/#13Alpha-channel-processing).
       doc-ref: https://www.w3.org/TR/png/#fcTL-chunk

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -59,12 +59,28 @@ types:
     seq:
       - id: len
         type: u4
-      - id: type
-        type: str
+      - id: type_raw
         size: 4
-        encoding: ASCII
         valid:
-          expr: type != "\0\0\0\0"
+          expr: |
+            (
+              (_[0] >= 0x41 and _[0] <= 0x5a) or
+              (_[0] >= 0x61 and _[0] <= 0x7a)
+            ) and (
+              (_[1] >= 0x41 and _[1] <= 0x5a) or
+              (_[1] >= 0x61 and _[1] <= 0x7a)
+            ) and (
+              (_[2] >= 0x41 and _[2] <= 0x5a) or
+              (_[2] >= 0x61 and _[2] <= 0x7a)
+            ) and (
+              (_[3] >= 0x41 and _[3] <= 0x5a) or
+              (_[3] >= 0x61 and _[3] <= 0x7a)
+            )
+        doc: |
+          Each byte of a chunk type is restricted to the hexadecimal values
+          0x41..0x5a and 0x61..0x7a, i.e. uppercase and lowercase ASCII letters
+          (`A-Z` and `a-z`).
+        doc-ref: https://www.w3.org/TR/2025/REC-png-3-20250624/#table51
       - id: body
         size: len
         type:
@@ -117,6 +133,9 @@ types:
             # seAl
       - id: crc
         type: u4
+    instances:
+      type:
+        value: type_raw.to_s('ASCII')
   ihdr_chunk:
     doc-ref: https://www.w3.org/TR/png/#11IHDR
     seq:

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -396,8 +396,9 @@ types:
         type: u1
   phys_chunk:
     doc: |
-      "Physical size" chunk stores data that allows to translate
-      logical pixels into physical units (meters, etc) and vice-versa.
+      Physical pixel dimensions (`pHYs`) chunk specifies the intended physical
+      size of the pixels (in meters) or pixel aspect ratio for display of the
+      image.
     doc-ref: https://www.w3.org/TR/png/#11pHYs
     seq:
       - id: pixels_per_unit_x
@@ -415,6 +416,15 @@ types:
         enum: phys_unit
         valid:
           in-enum: true
+    instances:
+      dots_per_inch_x:
+        value: pixels_per_unit_x * 0.0254
+        if: unit == phys_unit::meter
+        doc: Horizontal resolution (DPI)
+      dots_per_inch_y:
+        value: pixels_per_unit_y * 0.0254
+        if: unit == phys_unit::meter
+        doc: Vertical resolution (DPI)
   time_chunk:
     doc: |
       Time chunk stores time stamp of last modification of this image,

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -368,7 +368,7 @@ types:
     doc: |
       International text chunk effectively allows to store key-value string pairs in
       PNG container. Both "key" (keyword) and "value" (text) parts are
-      given in pre-defined subset of iso8859-1 without control
+      given in pre-defined subset of ISO-8859-1 without control
       characters.
     doc-ref: https://www.w3.org/TR/png/#11iTXt
     seq:
@@ -432,18 +432,18 @@ types:
     doc: |
       Text chunk effectively allows to store key-value string pairs in
       PNG container. Both "key" (keyword) and "value" (text) parts are
-      given in pre-defined subset of iso8859-1 without control
+      given in pre-defined subset of ISO-8859-1 without control
       characters.
     doc-ref: https://www.w3.org/TR/png/#11tEXt
     seq:
       - id: keyword
         type: strz
-        encoding: iso8859-1
+        encoding: ISO-8859-1
         doc: Indicates purpose of the following text data.
       - id: text
         type: str
         size-eos: true
-        encoding: iso8859-1
+        encoding: ISO-8859-1
   compressed_text_chunk:
     doc: |
       Compressed text chunk effectively allows to store key-value
@@ -578,7 +578,7 @@ types:
     seq:
       - id: file_name
         type: strz
-        encoding: utf-8
+        encoding: UTF-8
         valid:
           # See https://github.com/skeeto/scratch/blob/58470254f4a95cdf7a53888e405c851c21eb2cae/pngattach/pngattach.c#L466-L468
           expr: _.length != 0 and _.substring(0, 1) != "."

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -603,7 +603,7 @@ types:
           The remaining control characters (U+0001..U+0009, U+000B..0+001F,
           U+007F..U+009F) are discouraged.
   animation_control_chunk:
-    doc-ref: https://wiki.mozilla.org/APNG_Specification#.60acTL.60:_The_Animation_Control_Chunk
+    doc-ref: https://www.w3.org/TR/png/#acTL-chunk
     seq:
       - id: num_frames
         type: u4
@@ -612,7 +612,7 @@ types:
         type: u4
         doc: Number of times to loop, 0 indicates infinite looping.
   frame_control_chunk:
-    doc-ref: https://wiki.mozilla.org/APNG_Specification#.60fcTL.60:_The_Frame_Control_Chunk
+    doc-ref: https://www.w3.org/TR/png/#fcTL-chunk
     seq:
       - id: sequence_number
         type: u4
@@ -658,7 +658,7 @@ types:
         value: 'delay_num / (delay_den == 0 ? 100.0 : delay_den)'
         doc: Time to display this frame, in seconds
   frame_data_chunk:
-    doc-ref: https://wiki.mozilla.org/APNG_Specification#.60fdAT.60:_The_Frame_Data_Chunk
+    doc-ref: https://www.w3.org/TR/png/#fdAT-chunk
     seq:
       - id: sequence_number
         type: u4
@@ -776,26 +776,28 @@ enums:
       doc: |
         No disposal is done on this frame before rendering the next;
         the contents of the output buffer are left as is.
-      doc-ref: https://wiki.mozilla.org/APNG_Specification#.60fcTL.60:_The_Frame_Control_Chunk
+      doc-ref: https://www.w3.org/TR/png/#fcTL-chunk
     1:
       id: background
       doc: |
         The frame's region of the output buffer is to be cleared to
         fully transparent black before rendering the next frame.
-      doc-ref: https://wiki.mozilla.org/APNG_Specification#.60fcTL.60:_The_Frame_Control_Chunk
+      doc-ref: https://www.w3.org/TR/png/#fcTL-chunk
     2:
       id: previous
       doc: |
         The frame's region of the output buffer is to be reverted
         to the previous contents before rendering the next frame.
-      doc-ref: https://wiki.mozilla.org/APNG_Specification#.60fcTL.60:_The_Frame_Control_Chunk
+      doc-ref: https://www.w3.org/TR/png/#fcTL-chunk
   blend_op_values:
     0:
       id: source
       doc: |
         All color components of the frame, including alpha,
         overwrite the current contents of the frame's output buffer region.
+      doc-ref: https://www.w3.org/TR/png/#fcTL-chunk
     1:
       id: over
       doc: |
         The frame is composited onto the output buffer based on its alpha
+      doc-ref: https://www.w3.org/TR/png/#fcTL-chunk

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -136,6 +136,29 @@ types:
     instances:
       type:
         value: type_raw.to_s('ASCII')
+      is_ancillary:
+        value: type_raw[0] & 0x20 != 0
+        doc: |
+          false = critical chunk, true = ancillary chunk
+      is_private:
+        value: type_raw[1] & 0x20 != 0
+        doc: |
+          false = public chunk (defined by the W3C), true = private chunk (can
+          be defined by anyone)
+      reserved_bit:
+        value: type_raw[2] & 0x20 != 0
+        doc: |
+          Should be `false`, i.e. all chunk types should have uppercase third
+          letters (the lowercase third letter is reserved for possible future
+          extensions to the PNG standard)
+      is_safe_to_copy:
+        value: type_raw[3] & 0x20 != 0
+        doc: |
+          Defines whether the chunk may be copied if the image data (i.e.
+          pixels) is modified. This tells PNG editors how to handle unknown
+          chunks - see section [14.2 Behavior of PNG
+          editors](https://www.w3.org/TR/2025/REC-png-3-20250624/#14Ordering) in
+          the official specification.
   ihdr_chunk:
     doc-ref: https://www.w3.org/TR/png/#11IHDR
     seq:

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -401,15 +401,30 @@ types:
         type: strz
         encoding: ASCII
         doc: |
-          Human language used in `translated_keyword` and `text`
-          attributes - should be a language code conforming to ISO
-          646.IRV:1991.
+          Human language used in the `translated_keyword` and `text` fields.
+
+          From the [official
+          specification](https://www.w3.org/TR/2025/REC-png-3-20250624/#11iTXt):
+
+          > The language tag is a well-formed language tag defined by [RFC 5646:
+          > BCP 47: Tags for Identifying
+          > Languages](https://www.rfc-editor.org/info/rfc5646/). Unlike the
+          > keyword, the language tag is case-insensitive. Subtags must appear
+          > in the [IANA language subtag
+          > registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
+          > If the language tag is empty, the language is unspecified. Examples
+          > of language tags include: `en`, `en-GB`, `es-419`, `zh-Hans`,
+          > `zh-Hans-CN`, `tlh-Cyrl-AQ`, `ar-AE-u-nu-latn`, and `x-private`.
       - id: translated_keyword
         type: strz
         encoding: UTF-8
         doc: |
-          Keyword translated into language specified in
-          `language_tag`. Line breaks are not allowed.
+          The keyword (`keyword`) translated into the language specified in
+          `language_tag`.
+
+          It must not contain a zero byte (U+0000 NULL character). Line breaks
+          should not appear. The remaining control characters (U+0001..U+0009,
+          U+000B..0+001F, U+007F..U+009F) are discouraged.
       - id: text_plain
         size-eos: true
         type: international_text
@@ -426,9 +441,15 @@ types:
       text:
         value: '(compression_flag == 0 ? text_plain : text_zlib).text'
         doc: |
-          Text contents ("value" of this key-value pair), written in
-          language specified in `language_tag`. Line breaks are
-          allowed.
+          Text string (the "value" of this key-value pair), written in language
+          specified in `language_tag`.
+
+          Although it is not null-terminated (unlike other textual data in the
+          `iTXt` chunk), it must not contain a zero byte
+          (U+0000 NULL character). A newline should be represented by a single
+          U+000A LINE FEED (LF) character (aka `\n`). The remaining control
+          characters (U+0001..U+0009, U+000B..0+001F, U+007F..U+009F) are
+          discouraged.
   international_text:
     seq:
       - id: text
@@ -436,9 +457,15 @@ types:
         encoding: UTF-8
         size-eos: true
         doc: |
-          Text contents ("value" of this key-value pair), written in
-          language specified in `language_tag`. Line breaks are
-          allowed.
+          Text string (the "value" of this key-value pair), written in language
+          specified in `_parent.language_tag`.
+
+          Although it is not null-terminated (unlike other textual data in the
+          `iTXt` chunk), it must not contain a zero byte
+          (U+0000 NULL character). A newline should be represented by a single
+          U+000A LINE FEED (LF) character (aka `\n`). The remaining control
+          characters (U+0001..U+0009, U+000B..0+001F, U+007F..U+009F) are
+          discouraged.
   text_chunk:
     doc: |
       Textual data (`tEXt`) chunk effectively allows you to store key-value
@@ -466,6 +493,14 @@ types:
         type: str
         size-eos: true
         encoding: ISO-8859-1
+        doc: |
+          Text string (the "value" of this key-value pair).
+
+          Although it is not null-terminated (unlike the keyword), it must not
+          contain a zero byte (U+0000 NULL character). A newline should be
+          represented by a single U+000A LINE FEED (LF) character (aka `\n`).
+          The remaining control characters (U+0001..U+0009, U+000B..0+001F,
+          U+007F..U+009F) are discouraged.
   compressed_text_chunk:
     doc: |
       Compressed textual data (`zTXt`) chunk effectively allows you to store

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -452,6 +452,15 @@ types:
       - id: compression_method
         type: u1
         enum: compression_methods
+        # The [specification](https://www.w3.org/TR/2025/REC-png-3-20250624/#11iTXt)
+        # says that for uncompressed text (i.e. when `compression_flag == 0`),
+        # decoders must ignore the compression method.
+        #
+        # We reflect this in the validation check: we require that the
+        # compression method be 0 (zlib) only if `compression_flag == 1`;
+        # otherwise, we disable the check by turning it into the tautology
+        # `compression_method == compression_method` (which is always true).
+        valid: 'compression_flag == 1 ? compression_methods::zlib : compression_method'
       - id: language_tag
         type: strz
         encoding: ASCII
@@ -583,6 +592,7 @@ types:
       - id: compression_method
         type: u1
         enum: compression_methods
+        valid: compression_methods::zlib
       - id: text
         size-eos: true
         process: zlib

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -632,7 +632,9 @@ types:
     seq:
       - id: num_frames
         type: u4
-        doc: Number of frames, must be equal to the number of `frame_control_chunk`s
+        doc: |
+          Number of frames, must be equal to the number of `fcTL` chunks (i.e.
+          `frame_control_chunk` objects)
       - id: num_plays
         type: u4
         doc: Number of times to loop, 0 indicates infinite looping.
@@ -641,7 +643,22 @@ types:
     seq:
       - id: sequence_number
         type: u4
-        doc: Sequence number of the animation chunk
+        # NOTE: whenever you update this `doc`, be sure to also update its copy
+        # in `frame_data_chunk`
+        doc: |
+          Sequence number of the animation chunk, starting from 0.
+
+          The `fcTL` and `fdAT` chunks have a 4-byte sequence number. Both chunk
+          types share the sequence. The purpose of this number is to detect (and
+          optionally correct) sequence errors in an Animated PNG, since the PNG
+          specification does not impose ordering restrictions on ancillary
+          chunks (which means that a PNG editor is technically allowed to
+          reorder them arbitrarily, see [14.2 Behavior of PNG
+          editors](https://www.w3.org/TR/png/#14Ordering) in the spec).
+
+          The first `fcTL` chunk must contain sequence number 0, and the
+          sequence numbers in the remaining `fcTL` and `fdAT` chunks must be in
+          ascending order, with no gaps or duplicates.
       - id: width
         type: u4
         valid:
@@ -691,18 +708,30 @@ types:
     seq:
       - id: sequence_number
         type: u4
+        # NOTE: whenever you update this `doc`, be sure to also update its copy
+        # in `frame_control_chunk`
         doc: |
-          Sequence number of the animation chunk. The fcTL and fdAT chunks
-          have a 4 byte sequence number. Both chunk types share the sequence.
-          The first fcTL chunk must contain sequence number 0, and the sequence
-          numbers in the remaining fcTL and fdAT chunks must be in order, with
-          no gaps or duplicates.
+          Sequence number of the animation chunk, starting from 0.
+
+          The `fcTL` and `fdAT` chunks have a 4-byte sequence number. Both chunk
+          types share the sequence. The purpose of this number is to detect (and
+          optionally correct) sequence errors in an Animated PNG, since the PNG
+          specification does not impose ordering restrictions on ancillary
+          chunks (which means that a PNG editor is technically allowed to
+          reorder them arbitrarily, see [14.2 Behavior of PNG
+          editors](https://www.w3.org/TR/png/#14Ordering) in the spec).
+
+          The first `fcTL` chunk must contain sequence number 0, and the
+          sequence numbers in the remaining `fcTL` and `fdAT` chunks must be in
+          ascending order, with no gaps or duplicates.
       - id: frame_data
         size-eos: true
         doc: |
-          Frame data for the frame. At least one fdAT chunk is required for
-          each frame. The compressed datastream is the concatenation of the
-          contents of the data fields of all the fdAT chunks within a frame.
+          Frame data for the frame. At least one `fdAT` chunk is required for
+          each frame, except for the first frame, if that frame is represented
+          by an `IDAT` chunk. The compressed datastream for each frame is the
+          concatenation of the contents of the data fields of all the `fdAT`
+          chunks within a frame.
   adobe_fireworks_chunk:
     doc-ref: https://stackoverflow.com/questions/4242402/the-fireworks-png-format-any-insight-any-libs/51683285#51683285
     seq:

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -262,6 +262,8 @@ types:
     seq:
       - id: gamma_int
         type: u4
+        valid:
+          expr: _ != 0
         doc: |
           Image gamma multiplied by 100000 (a gamma value of 1/2.2 is stored as
           45455)

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -439,7 +439,7 @@ types:
           - 706 # `process` does not work with `type: str`
     instances:
       text:
-        value: '(compression_flag == 0 ? text_plain : text_zlib).text'
+        value: '(compression_flag == 0 ? text_plain : text_zlib).value'
         doc: |
           Text string (the "value" of this key-value pair), written in language
           specified in `language_tag`.
@@ -452,7 +452,7 @@ types:
           discouraged.
   international_text:
     seq:
-      - id: text
+      - id: value
         type: str
         encoding: UTF-8
         size-eos: true
@@ -526,9 +526,25 @@ types:
       - id: compression_method
         type: u1
         enum: compression_methods
-      - id: text_datastream
-        process: zlib
+      - id: text
         size-eos: true
+        process: zlib
+        type: compressed_text
+        -affected-by: 706 # `process` does not work with `type: str`
+  compressed_text:
+    seq:
+      - id: value
+        type: str
+        encoding: ISO-8859-1
+        size-eos: true
+        doc: |
+          Text string (the "value" of this key-value pair).
+
+          Although it is not null-terminated (unlike the keyword), it must not
+          contain a zero byte (U+0000 NULL character). A newline should be
+          represented by a single U+000A LINE FEED (LF) character (aka `\n`).
+          The remaining control characters (U+0001..U+0009, U+000B..0+001F,
+          U+007F..U+009F) are discouraged.
   animation_control_chunk:
     doc-ref: https://wiki.mozilla.org/APNG_Specification#.60acTL.60:_The_Animation_Control_Chunk
     seq:

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -177,12 +177,23 @@ types:
       - id: color_type
         type: u1
         enum: color_type
+        valid:
+          in-enum: true
       - id: compression_method
         type: u1
+        enum: compression_methods
+        valid:
+          in-enum: true
       - id: filter_method
         type: u1
+        enum: filter_method
+        valid:
+          in-enum: true
       - id: interlace_method
         type: u1
+        enum: interlace_method
+        valid:
+          in-enum: true
   plte_chunk:
     doc-ref: https://www.w3.org/TR/png/#11PLTE
     seq:
@@ -341,6 +352,8 @@ types:
       - id: render_intent
         type: u1
         enum: intent
+        valid:
+          in-enum: true
     enums:
       intent:
         0: perceptual
@@ -400,6 +413,8 @@ types:
       - id: unit
         type: u1
         enum: phys_unit
+        valid:
+          in-enum: true
   time_chunk:
     doc: |
       Time chunk stores time stamp of last modification of this image,
@@ -822,3 +837,16 @@ enums:
         a simple OVER operation as described in [Alpha Channel
         Processing](https://www.w3.org/TR/png/#13Alpha-channel-processing).
       doc-ref: https://www.w3.org/TR/png/#fcTL-chunk
+  # https://www.w3.org/TR/png/#9Filters
+  filter_method:
+    0:
+      id: base
+      -orig-id: PNG_FILTER_TYPE_BASE
+      doc: Single row per-byte filtering
+      doc-ref:
+        - https://github.com/pnggroup/libpng/blob/dd5d363ae1fc7778f2734bf51b10d3fe65028671/png.h#L599
+        - https://www.w3.org/TR/png/#9Filter-types
+  # https://www.w3.org/TR/png/#8InterlaceMethods
+  interlace_method:
+    0: none
+    1: adam7

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -62,7 +62,7 @@ types:
       - id: type
         type: str
         size: 4
-        encoding: UTF-8
+        encoding: ASCII
         valid:
           expr: type != "\0\0\0\0"
       - id: body

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -365,6 +365,7 @@ types:
       - id: second
         type: u1
   international_text_chunk:
+    -webide-representation: '{keyword}'
     doc: |
       International textual data (`iTXt`) chunk effectively allows you to store
       key-value string pairs in the PNG container.
@@ -467,6 +468,7 @@ types:
           characters (U+0001..U+0009, U+000B..0+001F, U+007F..U+009F) are
           discouraged.
   text_chunk:
+    -webide-representation: '{keyword}'
     doc: |
       Textual data (`tEXt`) chunk effectively allows you to store key-value
       string pairs in the PNG container.
@@ -502,6 +504,7 @@ types:
           The remaining control characters (U+0001..U+0009, U+000B..0+001F,
           U+007F..U+009F) are discouraged.
   compressed_text_chunk:
+    -webide-representation: '{keyword}'
     doc: |
       Compressed textual data (`zTXt`) chunk effectively allows you to store
       key-value string pairs in the PNG container, compressing the "value" part

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -47,7 +47,7 @@ seq:
   - id: ihdr
     type: ihdr_chunk
   - id: ihdr_crc
-    size: 4
+    type: u4
   # The rest of the chunks
   - id: chunks
     type: chunk
@@ -116,7 +116,7 @@ types:
             # https://github.com/hackerfactor/SEAL/blob/master/FORMATS.md#png
             # seAl
       - id: crc
-        size: 4
+        type: u4
   ihdr_chunk:
     doc-ref: https://www.w3.org/TR/png/#11IHDR
     seq:


### PR DESCRIPTION
This brings various improvements to the PNG format spec:

1. parse CRCs as `u4` (not as byte arrays) - a4b8eb32d2dfb7608b9030f622e054cbc96a7d32
1. fix non-canonical encoding names for which KSC 0.11 issues warnings - 64655707f082ed1a92744bcfdf6b579942155e60 (<code><del>iso8859-1</del></code> -> <code><ins>**ISO-8859-1**</ins></code>, <code><del>utf-8</del></code> -> <code><ins>**UTF-8**</ins></code>)

   See https://doc.kaitai.io/ksy_style_guide.html#encoding-name

1. fix the encoding of the `keyword` field in `iTXt` and `zTXt` chunks - 2692b8f2343b55a4a19b7a9276847b1ac0b1fe4d (i.e. in types `international_text_chunk` and `compressed_text_chunk`)

   It was `UTF-8`, but the [official PNG spec](https://www.w3.org/TR/2025/REC-png-3-20250624/#11textinfo) mandates Latin-1 (`ISO-8859-1`). Perhaps the [old PNG 1.2 spec](https://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html#C.Anc-text) says it even more clearly:

   > Keywords are always interpreted according to the ISO/IEC 8859-1 (Latin-1) character set [[ISO/IEC-8859-1](https://www.libpng.org/pub/png/spec/1.2/PNG-References.html#B.I-8859-1)].

   Note: strictly speaking, ISO/IEC 8859-1 is not the same as `ISO-8859-1`, because in "ISO/IEC 8859-1", code points 0x00-0x1F, 0x7F and 0x80-0x9F are unassigned (rather than being assigned to C0 and C1 control codes as in `ISO-8859-1`), but it's the closest equivalent (superset).

1. actually parse the text string in the `zTXt` chunk - 40f998fcba50e5044ee5b20c7c719a40c8cfa29a (previously, parsing was left at decompressing the zlib bytes and providing as a raw byte array in the `text_datastream` field)
1. improve the docstrings (`doc` keys) in all text chunks - 2692b8f2343b55a4a19b7a9276847b1ac0b1fe4d, 839a3eca693849b51113c3230ac4105319ec9a91 (in particular, correct and clarify the set of allowed characters)

1. add `-webide-representation` to all three types of text chunks (`iTXt`, `tEXt`, and `zTXt`) - a57a4bcbdd7219fc5e6921c387bc4c5fadf9dc88

   Although the `Chunk` object still needs to be expanded first, the `body` field now displays the keyword in the collapsed state without having to expand it:

   <img width="337" height="353" alt="webide-png-object-tree-with-webide-repr-in-text-chunks" src="https://github.com/user-attachments/assets/0f2e57a6-6d4e-4fa3-9376-e7328f84fd1c" />

1. fully validate every chunk type using `valid/expr` - 0e3ab749d8626a5c5bc3946cd2c693e3df96403f

   The [PNG spec](https://www.w3.org/TR/2025/REC-png-3-20250624/#table51) requires that a chunk type consists entirely of uppercase and lowercase ASCII letters (`A-Z` and `a-z`). Now the `png.ksy` spec rejects files that don't meet this condition. For example:

   <img width="648" height="181" alt="webide-png-object-tree-chunk-type-valid-expr-error" src="https://github.com/user-attachments/assets/1c792ab6-d490-425d-b512-43d52682248a" />

1. improve the `gAMA` chunk - 1c9455abe73f7eed437e7cbf87206423414c0b92

   Previously, the only value instance provided was `gamma_ratio`, which actually calculated the inverse / reciprocal of the gamma value (for example, it returned `2.2` when the actual gamma value in the chunk was `0.45455`).

   Now there are two value instances available: `gamma` (e.g. `1/2.2 = 0.45455`) and `inv_gamma`, which is the inverse of the gamma (calculated in exactly the same way as the previous `gamma_ratio`).

1. validate that the gamma value in `gAMA` is not 0 - 774bd7d2f0fb4979c99d9bbf377d11d784fa867f

1. decode property bits of the chunk type - f9f15c9f77664c97c9cbff8dd1734d82d9ad9d44 (provide `is_ancillary`, `is_private`, `reserved_bit` and `is_safe_to_copy` boolean value instances)

1. change the `doc-ref` links in the APNG chunks so that they point to https://www.w3.org/TR/png/ instead of https://wiki.mozilla.org/APNG_Specification - 014900e40c498a702180280c01f95d8c16f57b6f

1. add `-orig-id` to enum members associated with the APNG chunk `fcTL` - e7b8ec24538756b28e7d22b868cd7dfe869b795d (the [official spec](https://www.w3.org/TR/png/#fcTL-chunk) always refers to them by these `APNG_DISPOSE_OP_*` and `APNG_BLEND_OP_*` names, so I think makes sense to mention them)

1. validate enum fields in all chunks, mostly using `valid/in-enum` - e277cf2b4c2e5cc624d3f049d87e6a46f1fda2d0, c3849b18ceaa9b40c0431fda719b0948474408b1, 0801979fb8fe4f6608b6ca32cf950462f9d38e4e

1. improve docstrings in APNG chunks - 34d4f3eeb0a275973c49de3c738fcb02841f5ab3 (previously, some sentences were slightly inaccurate; now we use more wording from the official specification, plus some of my own)

1. add value instances `dots_per_inch_{x,y}` to the `pHYs` chunk, which calculate horizontal/vertical resolution (DPI) - 1594eeebf6a97d619bd653d7c33e26d7ca7863d1
