### PR TITLE
png: add notice required by the W3C license to `/doc`

### DIFF
--- a/image/png.ksy
+++ b/image/png.ksy
@@ -38,6 +38,54 @@ doc: |
   Copyright © 1996-2025 [World Wide Web Consortium](https://www.w3.org/).
   <https://www.w3.org/copyright/software-license-2023/>
 
+  The full text of the license for the original W3C PNG specification is
+  provided below:
+
+  > ## Software and Document license - 2023 version
+  >
+  > This work is being provided by the copyright holders under the following
+  > license.
+  >
+  > ### License
+  >
+  > By obtaining and/or copying this work, you (the licensee) agree that you
+  > have read, understood, and will comply with the following terms and
+  > conditions.
+  >
+  > Permission to copy, modify, and distribute this work, with or without
+  > modification, for any purpose and without fee or royalty is hereby granted,
+  > provided that you include the following on ALL copies of the work or
+  > portions thereof, including modifications:
+  >
+  > * The full text of this NOTICE in a location viewable to users of the
+  >   redistributed or derivative work.
+  > * Any pre-existing intellectual property disclaimers, notices, or terms and
+  >   conditions. If none exist, the [W3C software and document short
+  >   notice](https://www.w3.org/Consortium/Legal/2023/copyright-software-short-notice.html)
+  >   should be included.
+  > * Notice of any changes or modifications, through a copyright statement on
+  >   the new code or document such as "This software or document includes
+  >   material copied from or derived from [title and URI of the W3C document].
+  >   Copyright © [$year-of-document] [World Wide Web
+  >   Consortium](https://www.w3.org/).
+  >   <https://www.w3.org/copyright/software-license-2023/>"
+  >
+  > ### Disclaimers
+  >
+  > THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS
+  > OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES
+  > OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF
+  > THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS,
+  > COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+  >
+  > COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+  > CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+  >
+  > The name and trademarks of copyright holders may NOT be used in advertising
+  > or publicity pertaining to the work without specific, written prior
+  > permission. Title to copyright in this work will at all times remain with
+  > copyright holders.
+
   ---
 
   Test files for APNG can be found at the following locations:

--- a/image/png.ksy
+++ b/image/png.ksy
@@ -32,6 +32,14 @@ meta:
     - exif
   endian: be
 doc: |
+  NOTICE: Many of the documentation comments (or docstrings) in this file were
+  copied from or derived from the [Portable Network Graphics (PNG) Specification
+  (Third Edition)](https://www.w3.org/TR/2025/REC-png-3-20250624/).
+  Copyright © 1996-2025 [World Wide Web Consortium](https://www.w3.org/).
+  <https://www.w3.org/copyright/software-license-2023/>
+
+  ---
+
   Test files for APNG can be found at the following locations:
 
     * <https://philip.html5.org/tests/apng/tests.html>


### PR DESCRIPTION
Since the `png.ksy` spec contains many excerpts from the W3C specification https://www.w3.org/TR/png/ to document types and fields using the `doc` key, I believe this notice is likely required.

https://www.w3.org/TR/2025/REC-png-3-20250624/ has the following notice:

> [Copyright](https://www.w3.org/policies/#copyright) © 1996-2025 [World Wide Web Consortium](https://www.w3.org/). W3C® [liability](https://www.w3.org/policies/#Legal_Disclaimer), [trademark](https://www.w3.org/policies/#W3C_Trademarks) and [permissive document license](https://www.w3.org/copyright/software-license-2023/) rules apply.

From this, I concluded that the W3C PNG spec is under the [Software and Document license - 2023 version](https://www.w3.org/copyright/software-license-2023/). I noticed there is also a [Document license - 2023 version](https://www.w3.org/copyright/document-license-2023/), but it doesn't seem to be used by the PNG spec (it's probably used by some other W3C documents).