### PR TITLE
exif: update `/meta/xref`, add `/doc-ref` with links to Exif standards

### DIFF
--- a/image/exif.ksy
+++ b/image/exif.ksy
@@ -3,13 +3,17 @@ meta:
   xref:
     forensicswiki: exif
     justsolve: Exif
-    loc: fdd000146
+    loc:
+      - fdd000618 # Exif family
+      - fdd000146 # Exif 2.2
     pronom:
       - x-fmt/398 # Exif 2.0
       - x-fmt/390 # Exif 2.1
       - x-fmt/391 # Exif 2.2
-      - fmt/645 # Exif 2.21 ("2.2.1" in PRONOM is misspelled)
-    wikidata: Q26383099
+      - fmt/645 # Exif 2.21
+    wikidata:
+      - Q26383099 # Exif image file
+      - Q196465 # Exchangeable image file format
   license: CC0-1.0
 seq:
   - id: endianness

--- a/image/exif.ksy
+++ b/image/exif.ksy
@@ -15,6 +15,15 @@ meta:
       - Q26383099 # Exif image file
       - Q196465 # Exchangeable image file format
   license: CC0-1.0
+doc-ref:
+  - https://www.cipa.jp/std/documents/download_e.html?CIPA_DC-008-2026-E Exif Version 3.1
+  - https://www.cipa.jp/std/documents/download_e.html?CIPA_DC-008-2024-E Exif Version 3.0
+  - https://web.archive.org/web/20190624045241id_/https://www.cipa.jp/std/documents/e/DC-008-Translation-2019-E.pdf Exif Version 2.32
+  - https://web.archive.org/web/20190712232333id_/https://www.cipa.jp/std/documents/e/DC-008-Translation-2016-E.pdf Exif Version 2.31
+  - https://www.cipa.jp/std/documents/e/DC-008-2012_E_C.pdf Exif Version 2.3 (with Corrigendum at the end)
+  - https://web.archive.org/web/20051228234707id_/https://tsc.jeita.or.jp/avs/data/cp3451_1.pdf Exif Version 2.21 (2003 draft)
+  - https://web.archive.org/web/20131018091152id_/https://exif.org/Exif2-2.PDF Exif Version 2.2
+  - https://web.archive.org/web/20131111073619id_/https://exif.org/Exif2-1.PDF Exif Version 2.1
 seq:
   - id: endianness
     type: u2le

--- a/image/exif.ksy
+++ b/image/exif.ksy
@@ -15,6 +15,7 @@ meta:
       - Q26383099 # Exif image file
       - Q196465 # Exchangeable image file format
   license: CC0-1.0
+  ks-version: '0.9'
 doc-ref:
   - https://www.cipa.jp/std/documents/download_e.html?CIPA_DC-008-2026-E Exif Version 3.1
   - https://www.cipa.jp/std/documents/download_e.html?CIPA_DC-008-2024-E Exif Version 3.0

--- a/image/exif.ksy
+++ b/image/exif.ksy
@@ -1,5 +1,6 @@
 meta:
   id: exif
+  title: Exchangeable image file format (Exif)
   xref:
     forensicswiki: exif
     justsolve: Exif


### PR DESCRIPTION
Adding links to the official Exif standards will make maintenance easier, since it will be possible to consult the official specifications right away without having to search for them each time.

I also extended/updated the references in `/meta/xref`.